### PR TITLE
CI: update-flakes: remove `--recreate-lock-file`

### DIFF
--- a/.github/workflows/update-flakes.yaml
+++ b/.github/workflows/update-flakes.yaml
@@ -21,7 +21,7 @@ jobs:
             experimental-features = nix-command flakes
 
       - name: Update flakes
-        run: nix flake update --recreate-lock-file
+        run: nix flake update
 
       - name: Create Pull Request
         id: cpr


### PR DESCRIPTION
The `--recreate-lock-file` switch is no longer available for `nix flake update`. Its usage is limited to all the other commands which operate on a flake.