### PR TITLE
Flake: remove test from ryantm/agenix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1620668778,
-        "narHash": "sha256-Rp0jdlW4n1dLHsf6om3F8++lRBjzO6zNIeOYCrFK86c=",
+        "lastModified": 1620877075,
+        "narHash": "sha256-XvgTqtmQZHegu9UMDSR50gK5cHEM2gbnRH0qecmdN54=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "c27b6334a21384fd55cc6087630e2233ab7a0226",
+        "rev": "e543aa7d68f222e1e771165da9e9a64b5bf7b3e3",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1620387763,
-        "narHash": "sha256-cR6e92q0fMMol0K5a+e472F2ojjEoaEighs51pKF99I=",
+        "lastModified": 1621073999,
+        "narHash": "sha256-Cp99YreSFedcWovxNmO8g8qFYltQQJPRLfuot6Z7iGE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae1c8ede09b53007ba9b3c32f926c9c03547ae8b",
+        "rev": "83d907fd760d9ee4f49b4b7e4b1c6682f137b573",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1620787725,
-        "narHash": "sha256-vpZ/RAXyFzsvxbZxlKU9yUHnJPDKiAp2qD9tj95ty6M=",
+        "lastModified": 1621132284,
+        "narHash": "sha256-LtAkxh4E1cQcLe7KhB2Eaa7kx0yXYU8y9MGP5QTTKss=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47b1a05938dff7b279e4b93a7cb61c31746a5293",
+        "rev": "d343acc771891e7e90d2931a54facd8033b12c07",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -240,12 +240,6 @@
               )
             '';
           };
-
-        # Passthrough of the agenix integration test
-        checks.agenix-integration = import (agenix + "/test/integration.nix") {
-          inherit nixpkgs system;
-          pkgs = pkgsFor system;
-        };
       })
       )
       #


### PR DESCRIPTION
This partially reverts 6ddbf0baefd06abbed23e1578aa0bc034070a6b0.

Don't passthru the agenix integrations test:

- Public GitHub Actions runners complain about f-strings without any placeholders. This causes the pipeline to fail.
- Running the test with the public runners is rather flaky. The pipeline fails approx. every second time without a clear reason. Obviously, that's quite annoying.
- Last but not least: upstream should run this test in their pipeline. At the moment, running the test in our pipeline doesn't do much for ragenix as the check only tests the agenix NixOS module which we just pass through.