### PR TITLE
Flake: add support for aarch64-darwin

### DIFF
--- a/.github/workflows/macos-aarch64.yml
+++ b/.github/workflows/macos-aarch64.yml
@@ -1,0 +1,34 @@
+
+name: macOS aarch64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
+      - name: Set SDKROOT
+        run: echo "SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)" >> $GITHUB_ENV
+      - name: Set MACOSX_DEPLOYMENT_TARGET
+        run: echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)" >> $GITHUB_ENV
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target aarch64-apple-darwin 

--- a/flake.lock
+++ b/flake.lock
@@ -42,26 +42,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1623927034,
-        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
-        "owner": "nmattia",
+        "lastModified": 1625764329,
+        "narHash": "sha256-fD7BGYOevNg0WjFErDg6U4ykAyp1NNW5i2FmcQojiVA=",
+        "owner": "yaxitech",
         "repo": "naersk",
-        "rev": "e09c320446c5c2516d430803f7b19f5833781337",
+        "rev": "373da7b239ed0a6e0f78db00039a70ba5119b434",
         "type": "github"
       },
       "original": {
-        "owner": "nmattia",
+        "owner": "yaxitech",
+        "ref": "aarch64-darwin",
         "repo": "naersk",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1625281901,
-        "narHash": "sha256-DkZDtTIPzhXATqIps2ifNFpnI+PTcfMYdcrx/oFm00Q=",
+        "lastModified": 1625598452,
+        "narHash": "sha256-Oqh7nuZfEk+nkspGN5MS5ZTJ3dSxsUudTRvY/iUFad8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "09c38c29f2c719cd76ca17a596c2fdac9e186ceb",
+        "rev": "00c86ad14639887ec495b92ada9cd93a75317686",
         "type": "github"
       },
       "original": {
@@ -90,11 +91,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1625364738,
-        "narHash": "sha256-TPlpEcywGnB8jNIPOlCqFVbioskGOpasrVhxdw0BHzA=",
+        "lastModified": 1625710492,
+        "narHash": "sha256-RxDPd9Bn6o14z+Qveli5+8Hg//HBjFxk9wrwirH/im8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f08a653d9d6bbf06b5cc5dd1e570f1c449acbcf3",
+        "rev": "ef63c03223f00f1fc01a574597c02176fb28d689",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       inputs.flake-utils.follows = "flake-utils";
     };
     naersk = {
-      url = "github:nmattia/naersk";
+      url = "github:yaxitech/naersk/aarch64-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     agenix = {
@@ -32,8 +32,8 @@
       # Recursively merge a list of attribute sets. Following elements take
       # precedence over previous elements if they have conflicting keys.
       recursiveMerge = with lib; foldl recursiveUpdate { };
-
-      eachDefaultSystem = flake-utils.lib.eachDefaultSystem;
+      defaultSystems = flake-utils.lib.defaultSystems ++ [ "aarch64-darwin" ];
+      eachDefaultSystem = flake-utils.lib.eachSystem (defaultSystems);
       eachLinuxSystem = flake-utils.lib.eachSystem (lib.filter (lib.hasSuffix "-linux") flake-utils.lib.defaultSystems);
 
       pkgsFor = system: import nixpkgs {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "nightly-2021-04-25"
+profile = "minimal"
+channel = "nightly-2021-07-01"
 components = [ "clippy-preview", "rls-preview", "rustfmt-preview", "rust-analysis", "rust-std", "rust-src", "rust-analyzer-preview" ]
 targets = [ ]


### PR DESCRIPTION
This adds support for Apple Silicon (aarch64-darwin).
As [naersk](https://github.com/nmattia/naersk) does not support aarch64-darwin yet, we use our own fork for now.