### PR TITLE
Flake: use upstream naersk

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,16 +42,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1631004655,
+        "lastModified": 1632266297,
         "narHash": "sha256-J1yeJk6Gud9ef2pEf6aKQemrfg1pVngYDSh+SAY94xk=",
-        "owner": "yaxitech",
+        "owner": "nix-community",
         "repo": "naersk",
-        "rev": "a0607ce2973483ab7b2ac145f6a298c0ef96f71d",
+        "rev": "ee7edec50b49ab6d69b06d62f1de554efccb1ccd",
         "type": "github"
       },
       "original": {
-        "owner": "yaxitech",
-        "ref": "rust-stable",
+        "owner": "nix-community",
         "repo": "naersk",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,7 @@
       inputs.flake-utils.follows = "flake-utils";
     };
     naersk = {
-      # Fork with PRs
-      # - 182: "Add support for aarch64-darwin"
-      # - 191: "Don't rely on unstable flags"
-      url = "github:yaxitech/naersk/rust-stable";
+      url = "github:nix-community/naersk";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     agenix = {


### PR DESCRIPTION
Upstream naersk now has support for 

- `aarch64-darwin`: https://github.com/nix-community/naersk/pull/182
- Stable Rust channel: https://github.com/nix-community/naersk/pull/191

That means, we no longer have to use our fork.