### PR TITLE
Flake: remove explicit support for `aarch64-darwin`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
       # Recursively merge a list of attribute sets. Following elements take
       # precedence over previous elements if they have conflicting keys.
       recursiveMerge = with lib; foldl recursiveUpdate { };
-      defaultSystems = flake-utils.lib.defaultSystems ++ [ "aarch64-darwin" ];
+      defaultSystems = flake-utils.lib.defaultSystems;
       eachDefaultSystem = flake-utils.lib.eachSystem (defaultSystems);
       eachLinuxSystem = flake-utils.lib.eachSystem (lib.filter (lib.hasSuffix "-linux") flake-utils.lib.defaultSystems);
 


### PR DESCRIPTION
`aarch64-darwin` is now part of `flake-utils.lib.defaultSystems`
