### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1631962327,
-        "narHash": "sha256-h2fgtNHozEcB42BQ1QVWAJUpQ1FA3gpgq/RrOKAxbfE=",
+        "lastModified": 1633971123,
+        "narHash": "sha256-WmI4NbH1IPGFWVkuBkKoYgOnxgwSfWDgdZplJlQ93vA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc9b956714ed6eac5f8888322aac5bc41389defa",
+        "rev": "e4ef597edfd8a0ba5f12362932fc9b1dd01a0aef",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1632223470,
-        "narHash": "sha256-BVCa+epR2Bi5i5JS8rpk5F9llFkVX9KzJWmeRn4Mudg=",
+        "lastModified": 1634177806,
+        "narHash": "sha256-ZWssiqh6lVv8mSQqb4+OXm8PI+PL2kQ9ZLAkrfYi/Os=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d875f63082a3db25fa233d4ccd8f86b138c6cfeb",
+        "rev": "325ce5f355486e3e900ac9ec64809643fbc27732",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Resolved URL: git+file:///home/runner/work/ragenix/ragenix?shallow=1
Locked URL: git+file:///home/runner/work/ragenix/ragenix?ref=main&rev=1d83f5a25b83cfd1a3baf063ad4ef9388612ee12&shallow=1
Description: A rust drop-in replacement for agenix
Path: /nix/store/06m2na1cpshvmjv823gv4liijzlgf91d-source
Revision: 1d83f5a25b83cfd1a3baf063ad4ef9388612ee12
Last modified: 2021-10-14 19:51:11
Inputs:
├───agenix: github:ryantm/agenix/daf1d773989ac5d949aeef03fce0fe27e583dbca
│ └───nixpkgs follows input 'nixpkgs'
├───flake-utils: github:numtide/flake-utils/7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19
├───naersk: github:nix-community/naersk/ee7edec50b49ab6d69b06d62f1de554efccb1ccd
│ └───nixpkgs follows input 'nixpkgs'
├───nixpkgs: github:nixos/nixpkgs/e4ef597edfd8a0ba5f12362932fc9b1dd01a0aef
└───rust-overlay: github:oxalica/rust-overlay/325ce5f355486e3e900ac9ec64809643fbc27732
 ├───flake-utils follows input 'flake-utils'
 └───nixpkgs follows input 'nixpkgs'