### PR TITLE
CI: use `wurzelpfropf` binary cache from cachix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,13 +17,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: cachix/install-nix-action@v13
+      - name: Install Nix
+        uses: cachix/install-nix-action@v13
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/6l6zv3hfyqp402iax9jayd3i5qkmxx1f/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes recursive-nix
             system-features = nixos-test benchmark big-parallel kvm recursive-nix
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: wurzelpfropf
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN_PUBLIC }}'
       - name: 'Check flake evaluates'
         run: nix flake check --no-build .
       - name: 'Run checks'


### PR DESCRIPTION
In an effort to reduce the build times, use a public binary cache from cachix.

I've created the binary cache through @wurzelpfropf with the name `wurzelpfropf` and added an auth token as a secret with write access as `CACHIX_AUTH_TOKEN_PUBLIC` on the organization level.