### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1632266297,
-        "narHash": "sha256-J1yeJk6Gud9ef2pEf6aKQemrfg1pVngYDSh+SAY94xk=",
+        "lastModified": 1635444951,
+        "narHash": "sha256-1y3YkERwoYDIZjGow7HLAR8K3C/9VBPCBy8VpftMPsM=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "ee7edec50b49ab6d69b06d62f1de554efccb1ccd",
+        "rev": "0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1634782485,
-        "narHash": "sha256-psfh4OQSokGXG0lpq3zKFbhOo3QfoeudRcaUnwMRkQo=",
+        "lastModified": 1635403963,
+        "narHash": "sha256-0actzfzBAXvvDJ/EvPSGbtCPXUwSObQrcq0RpsPWZgA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
+        "rev": "2deb07f3ac4eeb5de1c12c4ba2911a2eb1f6ed61",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1635041777,
-        "narHash": "sha256-36LeviqJlWikocBObavRcaFnAQDdbr1Yaze2y7t0Ie0=",
+        "lastModified": 1635646580,
+        "narHash": "sha256-OdHejobtoEu2Q4j1OgriMRp39B2EWfu6N6/S4QbR5vc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "21ec729445fbf58ac59061c2694063799e9ee1aa",
+        "rev": "da39f01d3b2c5b710759908ac5011051ea100fc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Resolved URL: git+file:///home/runner/work/ragenix/ragenix?shallow=1
Locked URL: git+file:///home/runner/work/ragenix/ragenix?ref=main&rev=0c897a9881f290492c97eff2a8fc10348a61c159&shallow=1
Description: A rust drop-in replacement for agenix
Path: /nix/store/psmwww1m6dcpkd3rnp177wgdq8lsp242-source
Revision: 0c897a9881f290492c97eff2a8fc10348a61c159
Last modified: 2021-10-31 02:33:06
Inputs:
├───agenix: github:ryantm/agenix/53aa91b4170da35a96fab1577c9a34bc0da44e27
│ └───nixpkgs follows input 'nixpkgs'
├───flake-utils: github:numtide/flake-utils/c91f3de5adaf1de973b797ef7485e441a65b8935
├───naersk: github:nix-community/naersk/0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6
│ └───nixpkgs follows input 'nixpkgs'
├───nixpkgs: github:nixos/nixpkgs/2deb07f3ac4eeb5de1c12c4ba2911a2eb1f6ed61
├───nixpkgs-nixos-test: github:nixos/nixpkgs/e1fc1a80a071c90ab65fb6eafae5520579163783
└───rust-overlay: github:oxalica/rust-overlay/da39f01d3b2c5b710759908ac5011051ea100fc6
 ├───flake-utils follows input 'flake-utils'
 └───nixpkgs follows input 'nixpkgs'
```