### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1635444951,
-        "narHash": "sha256-1y3YkERwoYDIZjGow7HLAR8K3C/9VBPCBy8VpftMPsM=",
+        "lastModified": 1636103400,
+        "narHash": "sha256-6DRg/0P9oT5I/V02sloqGVHf8F6f+7DFoBZNPdr+hOI=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6",
+        "rev": "074d81b1a45145f076b2adf93184073fc9615397",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1635403963,
-        "narHash": "sha256-0actzfzBAXvvDJ/EvPSGbtCPXUwSObQrcq0RpsPWZgA=",
+        "lastModified": 1635844945,
+        "narHash": "sha256-tZcL307dj28jgEU1Wdn+zwG9neyW0H2+ZjdVhvJxh9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2deb07f3ac4eeb5de1c12c4ba2911a2eb1f6ed61",
+        "rev": "b67e752c29f18a0ca5534a07661366d6a2c2e649",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1635646580,
-        "narHash": "sha256-OdHejobtoEu2Q4j1OgriMRp39B2EWfu6N6/S4QbR5vc=",
+        "lastModified": 1636251445,
+        "narHash": "sha256-N05TJfuq+JaTLfYMN2GVrzwMEOZXwo467E+B2cKO+mk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "da39f01d3b2c5b710759908ac5011051ea100fc6",
+        "rev": "0385d848c7fbb36dc22851d6ade00c76a6157f53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Resolved URL: git+file:///home/runner/work/ragenix/ragenix?shallow=1
Locked URL: git+file:///home/runner/work/ragenix/ragenix?ref=main&rev=0c44de0fe7c89af53498fba571d7aca7219b0456&shallow=1
Description: A rust drop-in replacement for agenix
Path: /nix/store/4m9gx1ip764n921b2ajx0pydh8l7pp1s-source
Revision: 0c44de0fe7c89af53498fba571d7aca7219b0456
Last modified: 2021-11-07 09:13:07
Inputs:
├───agenix: github:ryantm/agenix/53aa91b4170da35a96fab1577c9a34bc0da44e27
│ └───nixpkgs follows input 'nixpkgs'
├───flake-utils: github:numtide/flake-utils/c91f3de5adaf1de973b797ef7485e441a65b8935
├───naersk: github:nix-community/naersk/074d81b1a45145f076b2adf93184073fc9615397
│ └───nixpkgs follows input 'nixpkgs'
├───nixpkgs: github:nixos/nixpkgs/b67e752c29f18a0ca5534a07661366d6a2c2e649
├───nixpkgs-nixos-test: github:nixos/nixpkgs/e1fc1a80a071c90ab65fb6eafae5520579163783
└───rust-overlay: github:oxalica/rust-overlay/0385d848c7fbb36dc22851d6ade00c76a6157f53
 ├───flake-utils follows input 'flake-utils'
 └───nixpkgs follows input 'nixpkgs'
```