### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637793790,
-        "narHash": "sha256-oPXavjxETEWGXq8g7kQHyRLKUmLX2yPtGn+t3V0mrTY=",
+        "lastModified": 1638319138,
+        "narHash": "sha256-ve33f4nTKQluyvm5URQwL019x0Fnrg8urqzvymNeD+s=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "f85eea0e29fa9a8924571d0e398215e175f80d55",
+        "rev": "52ea2f8c3231cc2b5302fa28c63588aacb77ea29",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637576998,
-        "narHash": "sha256-bGQ66hh4Dl78T9bd1pqdp6fprHMCkrkeKqED6sDUYqo=",
+        "lastModified": 1638203339,
+        "narHash": "sha256-Sz3iCvbWrVWOD/XfYQeRJgP/7MVYL3/VKsNXvDeWBFc=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "b043f2447a4a761529254f4983cacd94b034a122",
+        "rev": "c3e56b8a4ffb6d906cdfcfee034581f9a8ece571",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637841632,
-        "narHash": "sha256-QYqiKHdda0EOnLGQCHE+GluD/Lq2EJj4hVTooPM55Ic=",
+        "lastModified": 1638376152,
+        "narHash": "sha256-ucgLpVqhFnClH7YRUHBHnmiOd82RZdFR3XJt36ks5fE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73369f8d0864854d1acfa7f1e6217f7d6b6e3fa1",
+        "rev": "6daa4a5c045d40e6eae60a3b6e427e8700f1c07f",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638065687,
-        "narHash": "sha256-T8s/mgeS74Qtk48HEnZiQxpleekJP6rFPgkffG7imBc=",
+        "lastModified": 1638670773,
+        "narHash": "sha256-RU8c9o4v9t3XfLenD6aRIrQa0RO5QJ5194UJ0V7c5uE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1cd4ebce6b21f9aa38bfa3d5021135ea5568797f",
+        "rev": "88ce9c458d9e4dedfd9eed85a3fe818730a2fac5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Resolved URL: git+file:///home/runner/work/ragenix/ragenix?shallow=1
Locked URL: git+file:///home/runner/work/ragenix/ragenix?ref=main&rev=36679efd2f4818035e2d7db900db0f3010e6fb3c&shallow=1
Description: A rust drop-in replacement for agenix
Path: /nix/store/6ilzzimnv33lqqldp9nna6ihsvb731i0-source
Revision: 36679efd2f4818035e2d7db900db0f3010e6fb3c
Last modified: 2021-12-05 02:38:46
Inputs:
├───agenix: github:ryantm/agenix/52ea2f8c3231cc2b5302fa28c63588aacb77ea29
│ └───nixpkgs follows input 'nixpkgs'
├───flake-utils: github:numtide/flake-utils/74f7e4319258e287b0f9cb95426c9853b282730b
├───naersk: github:nix-community/naersk/c3e56b8a4ffb6d906cdfcfee034581f9a8ece571
│ └───nixpkgs follows input 'nixpkgs'
├───nixpkgs: github:nixos/nixpkgs/6daa4a5c045d40e6eae60a3b6e427e8700f1c07f
├───nixpkgs-nixos-test: github:nixos/nixpkgs/e1fc1a80a071c90ab65fb6eafae5520579163783
└───rust-overlay: github:oxalica/rust-overlay/88ce9c458d9e4dedfd9eed85a3fe818730a2fac5
 ├───flake-utils follows input 'flake-utils'
 └───nixpkgs follows input 'nixpkgs'
```