### PR TITLE
Flake: revert to NixOS test from nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637841632,
-        "narHash": "sha256-QYqiKHdda0EOnLGQCHE+GluD/Lq2EJj4hVTooPM55Ic=",
+        "lastModified": 1638376152,
+        "narHash": "sha256-ucgLpVqhFnClH7YRUHBHnmiOd82RZdFR3XJt36ks5fE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73369f8d0864854d1acfa7f1e6217f7d6b6e3fa1",
+        "rev": "6daa4a5c045d40e6eae60a3b6e427e8700f1c07f",
         "type": "github"
       },
       "original": {
@@ -71,29 +71,12 @@
         "type": "github"
       }
     },
-    "nixpkgs-nixos-test": {
-      "locked": {
-        "lastModified": 1632909223,
-        "narHash": "sha256-f8J2eG5n8eORyV1HLBA1PWojzSUbpvkYyuLSMHrGQKU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e1fc1a80a071c90ab65fb6eafae5520579163783",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e1fc1a80a071c90ab65fb6eafae5520579163783",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "agenix": "agenix",
         "flake-utils": "flake-utils",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-nixos-test": "nixpkgs-nixos-test",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,18 +20,14 @@
       url = "github:ryantm/agenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    # QEMU 6.1.0 hangs when running NixOS tests on a virtualized host, e.g., a GitHub Action runner
-    # Therefore, we use a NixOS Python test which still relies on QEMU 6.0.0.
-    # Upstream issue: https://github.com/NixOS/nixpkgs/issues/141596
-    nixpkgs-nixos-test.url = "github:nixos/nixpkgs/e1fc1a80a071c90ab65fb6eafae5520579163783";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, naersk, agenix, nixpkgs-nixos-test }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, naersk, agenix }:
     let
       cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       name = cargoTOML.package.name;
 
-      lib = import (nixpkgs + "/lib");
+      lib = import "${nixpkgs}/lib";
 
       # Recursively merge a list of attribute sets. Following elements take
       # precedence over previous elements if they have conflicting keys.
@@ -252,7 +248,7 @@
       (eachLinuxSystem (system: {
         checks.nixos-module =
           let
-            pythonTest = import (nixpkgs-nixos-test + "/nixos/lib/testing-python.nix") { inherit system; };
+            pythonTest = import ("${nixpkgs}/nixos/lib/testing-python.nix") { inherit system; };
             secretsConfig = import ./example/secrets-configuration.nix;
             secretPath = "/run/agenix/github-runner.token";
             ageSshKeysConfig = { lib, ... }: {


### PR DESCRIPTION
This partially reverts 2e93c056390df5bd78ae953c8ec1ae0e8727c04f.

The issue with the hanging Qemu is resolved. Hence, we can stick to the
latest version from nixos-unstable.
