### PR TITLE
Tooling: replace naersk with nixpkgs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,9 @@ jobs:
         with:
           name: wurzelpfropf
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN_PUBLIC }}'
-      - name: 'Run all checks'
+      - name: 'Check flake evaluates'
+        run: nix flake check --no-build .
+      - name: 'Run checks'
         run: nix flake check -L .
       - name: 'Build package'
         run: nix build -L .

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,9 +28,7 @@ jobs:
         with:
           name: wurzelpfropf
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN_PUBLIC }}'
-      - name: 'Check flake evaluates'
-        run: nix flake check --no-build .
-      - name: 'Run checks'
+      - name: 'Run all checks'
         run: nix flake check -L .
       - name: 'Build package'
         run: nix build -L .

--- a/flake.lock
+++ b/flake.lock
@@ -20,27 +20,6 @@
         "type": "github"
       }
     },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1639722305,
-        "narHash": "sha256-Tsh0JxclSqkCishs5DNApXf0kGx9VzOwYMfl/nbDkeA=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "16f025bc67a21fcd3f2d59ab37373e3d55bb5212",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1638122382,
@@ -75,25 +54,31 @@
     "root": {
       "inputs": {
         "agenix": "agenix",
-        "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1639175515,
-        "narHash": "sha256-Yj38u9BpKfyGrcSEaoSEnOns885xn/Ask6lR5rsxS8k=",
-        "owner": "rust-analyzer",
-        "repo": "rust-analyzer",
-        "rev": "d03397fe1173eaeb2e04c9e55ac223289e7e08ee",
+        "lastModified": 1639967969,
+        "narHash": "sha256-GdfgMyAgMY196E5PkDRSdC/RLih+b2DDkXXexAjOvmE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c609f104cbc2755b7cb4c0f63e0e86230d360cb5",
         "type": "github"
       },
       "original": {
-        "owner": "rust-analyzer",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1639722305,
+        "narHash": "sha256-Tsh0JxclSqkCishs5DNApXf0kGx9VzOwYMfl/nbDkeA=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "16f025bc67a21fcd3f2d59ab37373e3d55bb5212",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1638122382,
@@ -32,26 +53,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1639731602,
-        "narHash": "sha256-5u/J/7KrY/fYL/OeBLxP4E9NdNdQrriHpOyPBleKp5I=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "5415c7045366bb53db1a33cf7d975942b5553a28",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
         "type": "github"
       }
     },
@@ -74,32 +75,25 @@
     "root": {
       "inputs": {
         "agenix": "agenix",
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "nixpkgs": "nixpkgs"
       }
     },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+    "rust-analyzer-src": {
+      "flake": false,
       "locked": {
-        "lastModified": 1639880499,
-        "narHash": "sha256-/BibDmFwgWuuTUkNVO6YlvuTSWM9dpBvlZoTAPs7ORI=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "c6c83589ae048af20d93d01eb07a4176012093d0",
+        "lastModified": 1639175515,
+        "narHash": "sha256-Yj38u9BpKfyGrcSEaoSEnOns885xn/Ask6lR5rsxS8k=",
+        "owner": "rust-analyzer",
+        "repo": "rust-analyzer",
+        "rev": "d03397fe1173eaeb2e04c9e55ac223289e7e08ee",
         "type": "github"
       },
       "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
+        "owner": "rust-analyzer",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,16 @@
               export PATH="${rust}/bin:$PATH";
               # rustfmt
               cargo fmt -- --check
-              # clippy - needs to rebuild anyhow, so can as well check before the build
-              cargo clippy --all --all-features --tests -- -D clippy::pedantic -D warnings
+              # clippy - use same checkType as check-phase to avoid double building
+              if [ "''${cargoCheckType}" != "debug" ]; then
+                  cargoCheckProfileFlag="--''${cargoCheckType}"
+              fi
+              argstr="''${cargoCheckProfileFlag} --workspace --all-features --tests "
+              cargo clippy -j $NIX_BUILD_CORES \
+                 $argstr -- \
+                 -D clippy::pedantic \
+                 -D warnings
+
             '';
 
             # buildDeps

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,10 @@
       url = "github:numtide/flake-utils";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    fenix = {
-      url = "github:nix-community/fenix";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
     };
     agenix = {
       url = "github:ryantm/agenix";
@@ -17,7 +18,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, fenix, agenix }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, agenix }:
     let
       cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       name = cargoTOML.package.name;
@@ -33,7 +34,7 @@
 
       pkgsFor = system: import nixpkgs {
         inherit system;
-        overlays = [ fenix.overlay self.overlay ];
+        overlays = [ rust-overlay.overlay self.overlay ];
       };
     in
     recursiveMerge [
@@ -44,10 +45,7 @@
         let
           pkgs = pkgsFor system;
 
-          rust = fenix.packages.${system}.fromToolchainFile {
-            file = ./rust-toolchain;
-            sha256 = "sha256-6PfBjfCI9DaNRyGigEmuUP2pcamWsWGc4g7SNEHqD2c=";
-          };
+          rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
 
           buildRustPackage = (pkgs.makeRustPlatform {
             cargo = rust;


### PR DESCRIPTION
- change the tooling
- adapt check phase & execute checks before the build phase
- especially run the fmt check first to avoid building everything (twice)
  only to fail the build on format checks

closes #61
