### PR TITLE
nixos/age: sshKeyPaths -> identityPaths

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,12 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v13
+        uses: cachix/install-nix-action@v15
         with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/6l6zv3hfyqp402iax9jayd3i5qkmxx1f/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes recursive-nix
             system-features = nixos-test benchmark big-parallel kvm recursive-nix

--- a/example/secrets-configuration.nix
+++ b/example/secrets-configuration.nix
@@ -1,6 +1,6 @@
 {
   age.secrets."github-runner.token".file = ./github-runner.token.age;
-  age.sshKeyPaths = [
+  age.identityPaths = [
     "/persist/secrets/id_ed25519"
   ];
 }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637793790,
-        "narHash": "sha256-oPXavjxETEWGXq8g7kQHyRLKUmLX2yPtGn+t3V0mrTY=",
+        "lastModified": 1638837456,
+        "narHash": "sha256-WHLOxthAGx/wXw3QUa/lFE3mr6cQtnXfFYZ0DNyYwt4=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "f85eea0e29fa9a8924571d0e398215e175f80d55",
+        "rev": "57806bf7e340f4cae705c91748d4fdf8519293a9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -251,17 +251,17 @@
             pythonTest = import ("${nixpkgs}/nixos/lib/testing-python.nix") { inherit system; };
             secretsConfig = import ./example/secrets-configuration.nix;
             secretPath = "/run/agenix/github-runner.token";
-            ageSshKeysConfig = { lib, ... }: {
+            ageIdentitiesConfig = { lib, ... }: {
               # XXX: This is insecure and copies your private key plaintext to the Nix store
               #      NEVER DO THIS IN YOUR CONFIG!
-              age.sshKeyPaths = lib.mkForce [ ./example/keys/id_ed25519 ];
+              age.identityPaths = lib.mkForce [ ./example/keys/id_ed25519 ];
             };
           in
           pythonTest.makeTest {
             machine.imports = [
               self.nixosModules.age
               secretsConfig
-              ageSshKeysConfig
+              ageIdentitiesConfig
             ];
 
             testScript = ''


### PR DESCRIPTION
Adapt to upstream `agenix`: https://github.com/ryantm/agenix/pull/82
