### PR TITLE
Build without `recursive-nix`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,31 +6,51 @@ on:
   push:
     branches:
       - main
+
 jobs:
-  check:
-    env:
-      GC_DONT_GC: 1
-    name: 'Check and build'
+  build:
+    name: 'Build'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Nix
-        uses: cachix/install-nix-action@v15
+      - name: 'Checkout source'
+        uses: actions/checkout@v2
+      - name: 'Install Nix Flakes'
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: 'Setup Cachix'
+        uses: cachix/cachix-action@v10
+        with:
+          name: wurzelpfropf
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN_PUBLIC }}'
+      - name: 'Build default package'
+        run: nix build -L .
+
+  check:
+    name: 'Check'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: 'Checkout source'
+        uses: actions/checkout@v2
+      - name: 'Install Nix Flakes (nixos-test, recursive-nix)'
+        uses: cachix/install-nix-action@v16
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes recursive-nix
             system-features = nixos-test benchmark big-parallel kvm recursive-nix
-      - name: Setup Cachix
+      - name: 'Setup Cachix'
         uses: cachix/cachix-action@v10
         with:
           name: wurzelpfropf
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN_PUBLIC }}'
       - name: 'Check flake evaluates'
         run: nix flake check --no-build .
-      - name: 'Run checks'
+      - name: 'Run all checks'
         run: nix flake check -L .
-      - name: 'Build package'
-        run: nix build -L .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ version = "0.1.0"
 authors = ["Vincent Haupert <vincent@yaxi.tech>"]
 edition = "2021"
 
+[features]
+default = [ "recursive-nix" ]
+# Run tests which require a system with `recursive-nix` conditionally
+recursive-nix = []
+
 [dependencies]
 age = { version = "^0.7", default-features = false, features = [ "cli-common", "ssh", "armor", "plugin" ] }
 clap = { version = "3.0.0-rc.7", features = [ "cargo", "env" ] }

--- a/tests/ragenix.rs
+++ b/tests/ragenix.rs
@@ -23,6 +23,7 @@ fn copy_example_to_tmpdir() -> Result<(TempDir, PathBuf)> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn edit_no_rekey_if_unchanged() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 
@@ -49,6 +50,7 @@ fn edit_no_rekey_if_unchanged() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn edit_works() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 
@@ -70,12 +72,13 @@ fn edit_works() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn edit_new_entry() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let dir_path = fs::canonicalize(dir.path())?;
     let rules = indoc! {r#"
     {
-        "pandora.age".publicKeys = [ 
+        "pandora.age".publicKeys = [
             "age1qjzezkeazfdg4p9x0kjapjtreyyt74pg34ftzfypcdpy7wgh6acqxeyvwt"
         ];
     }
@@ -104,6 +107,7 @@ fn edit_new_entry() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn edit_new_entry_stdin() -> Result<()> {
     // # created: 2021-09-20T23:41:59+02:00
     // # public key: age1fjc9tyguvxfqh2ey2qqfc066g3gee7hlnhqn2g7yn4f6smymmsnq6xdn2t
@@ -113,7 +117,7 @@ fn edit_new_entry_stdin() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let rules = indoc! {r#"
     {
-        "pandora.age".publicKeys = [ 
+        "pandora.age".publicKeys = [
             "age1fjc9tyguvxfqh2ey2qqfc066g3gee7hlnhqn2g7yn4f6smymmsnq6xdn2t"
         ];
     }
@@ -157,6 +161,7 @@ fn edit_new_entry_stdin() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn edit_existing_entry_stdin() -> Result<()> {
     let plaintext = "secret wurzelpfropf";
 
@@ -193,6 +198,7 @@ fn edit_existing_entry_stdin() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn edit_permissions_correct() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
     let script = indoc! { r#"
@@ -235,6 +241,7 @@ fn edit_permissions_correct() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn rekeying_works() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 
@@ -261,6 +268,7 @@ fn rekeying_works() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn rekeying_ignores_not_existing_files() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 
@@ -284,6 +292,7 @@ fn rekeying_ignores_not_existing_files() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn rekeying_works_default_identities() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 
@@ -310,6 +319,7 @@ fn rekeying_works_default_identities() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn rekeying_fails_no_given_identites() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 
@@ -328,6 +338,7 @@ fn rekeying_fails_no_given_identites() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn rekeying_fails_no_valid_identites() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
     let ssh_dir = path.join(".ssh");
@@ -368,6 +379,7 @@ fn prints_schema() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn rejects_invalid_rules() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 
@@ -391,6 +403,7 @@ fn rejects_invalid_rules() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn fails_for_invalid_recipient() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let invalid_key = "invalid-key abcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
Refactor the code to allow building without `recursive-nix`:

- The Rust integration tests which require `recursive-nix` are guarded by a feature flag which is enabled by default (to still run them by just executing `cargo test`).
- `nix build` disables the `recursive-nix` feature flag. This allows using `ragenix` without a system with `recursive-nix` support. `nix flake check` will build `ragenix` (again) and run all tests.
- Building and checking are two separate CI workflows now. The former uses a Nix without `recursive-nix` while the latter uses a Nix installation with the `recursive-nix` feature enabled. Only the check workflow requires `recursive-nix`. 
- [macOS fails to run the `recursive-nix` checks](https://github.com/yaxitech/ragenix/runs/4632022485?check_suite_focus=true#step:6:818). I'm not sure what's the reason but it is probably an upstream bug. Therefore, I moved the respective checks to the Linux check outputs. We can revert the commit as soon as this is addressed.

Fixes #65 
