### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639699734,
-        "narHash": "sha256-tlX6WebGmiHb2Hmniff+ltYp+7dRfdsBxw9YczLsP60=",
+        "lastModified": 1640319671,
+        "narHash": "sha256-ZkKmakwaOaLiZOpIZWbeJZwap5CzJ30s4UJTfydYIYc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "03ec468b14067729a285c2c7cfa7b9434a04816c",
+        "rev": "eac07edbd20ed4908b98790ba299250b5527ecdf",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639967969,
-        "narHash": "sha256-GdfgMyAgMY196E5PkDRSdC/RLih+b2DDkXXexAjOvmE=",
+        "lastModified": 1640400025,
+        "narHash": "sha256-70lwBavskxJqPdD0TPoZMvpJHN6HTz7zZZ6FCROYxhk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c609f104cbc2755b7cb4c0f63e0e86230d360cb5",
+        "rev": "c46393bed399d74b709e74dc253b6c73914b8988",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Resolved URL: git+file:///home/runner/work/ragenix/ragenix?shallow=1
Locked URL: git+file:///home/runner/work/ragenix/ragenix?ref=main&rev=5965e31e28b69cafbd4671cc08d5f935b68466c9&shallow=1
Description: A rust drop-in replacement for agenix
Path: /nix/store/kk4ay9sj358jr562qps3wxpbb4bmlr0l-source
Revision: 5965e31e28b69cafbd4671cc08d5f935b68466c9
Last modified: 2021-12-26 02:41:31
Inputs:
├───agenix: github:ryantm/agenix/57806bf7e340f4cae705c91748d4fdf8519293a9
│ └───nixpkgs follows input 'nixpkgs'
├───flake-utils: github:numtide/flake-utils/74f7e4319258e287b0f9cb95426c9853b282730b
├───nixpkgs: github:nixos/nixpkgs/eac07edbd20ed4908b98790ba299250b5527ecdf
└───rust-overlay: github:oxalica/rust-overlay/c46393bed399d74b709e74dc253b6c73914b8988
 ├───flake-utils follows input 'flake-utils'
 └───nixpkgs follows input 'nixpkgs'
```