### PR TITLE
Append age plugins to `PATH`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -100,6 +100,6 @@ rustPlatform.buildRustPackage rec {
 
   # Make the plugins available in ragenix' PATH
   postFixup = lib.optionalString (plugins != [ ]) ''
-    wrapProgram "$out/bin/ragenix" --prefix PATH : ${lib.strings.makeBinPath plugins}
+    wrapProgram "$out/bin/ragenix" --suffix PATH : ${lib.strings.makeBinPath plugins}
   '';
 }


### PR DESCRIPTION
Append age plugins to `PATH` instead of prepending. This allows using an
updated version or a plugin for the same recipient without recompiling.
