### PR TITLE
Revert "Flake: use `ronn` from nixos/nixpkgs#155363"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642104392,
-        "narHash": "sha256-m71b7MgMh9FDv4MnI5sg9MiBVW6DhE1zq+d/KlLWSC8=",
+        "lastModified": 1642603785,
+        "narHash": "sha256-aDkVfZH4DFDI3EU0xrT9x/MGrwIYL4tQBT2czozaooc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5aaed40d22f0d9376330b6fa413223435ad6fee5",
+        "rev": "eefa3b6f9e244bda6de147ce6f61afd8e802a742",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -51,28 +51,11 @@
         "type": "github"
       }
     },
-    "nixpkgs-ronn": {
-      "locked": {
-        "lastModified": 1642436540,
-        "narHash": "sha256-D2eoDUNBiWszaQLFTCP2unffwTSLz5VaUHaG+QWsCXE=",
-        "owner": "veehaitch",
-        "repo": "nixpkgs",
-        "rev": "0df6b5ecb8173818a042a1bc840b5805a7ee6ee9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "veehaitch",
-        "ref": "ronn-r13y",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "agenix": "agenix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-ronn": "nixpkgs-ronn",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642603785,
-        "narHash": "sha256-aDkVfZH4DFDI3EU0xrT9x/MGrwIYL4tQBT2czozaooc=",
+        "lastModified": 1642635915,
+        "narHash": "sha256-vabPA32j81xBO5m3+qXndWp5aqepe+vu96Wkd9UnngM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eefa3b6f9e244bda6de147ce6f61afd8e802a742",
+        "rev": "6d8215281b2f87a5af9ed7425a26ac575da0438f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-ronn.url = "github:veehaitch/nixpkgs/ronn-r13y";
     flake-utils = {
       url = "github:numtide/flake-utils";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -19,7 +18,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-ronn, flake-utils, rust-overlay, agenix }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, agenix }:
     let
       cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       name = cargoTOML.package.name;
@@ -34,14 +33,9 @@
       eachDefaultSystem = eachSystem defaultSystems;
       eachLinuxSystem = eachSystem (lib.filter (lib.hasSuffix "-linux") flake-utils.lib.defaultSystems);
 
-      # XXX: remove when https://github.com/NixOS/nixpkgs/pull/155363 is merged
-      ronnOverlay = final: prev: {
-        ronn = prev.callPackage (nixpkgs-ronn + "/pkgs/development/tools/ronn") { };
-      };
-
       pkgsFor = system: import nixpkgs {
         inherit system;
-        overlays = [ rust-overlay.overlay self.overlay ronnOverlay ];
+        overlays = [ rust-overlay.overlay self.overlay ];
       };
     in
     recursiveMerge [


### PR DESCRIPTION
- Revert "Flake: use `ronn` from nixos/nixpkgs#155363"
- Flake.lock: temp. use revision from `nixpkgs/master`

Still needs a flake input update of `nixpkgs` as soon as nixos/nixpkgs#155492 is available in `nixos-unstable`: https://nixpk.gs/pr-tracker.html?pr=155492
