### PR TITLE
refactor(flake): don't use system alias

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -352,7 +352,7 @@
 
         # Overlay to add ragenix and replace agenix
         overlay = final: prev: rec {
-          ragenix = self.packages.${prev.system}.ragenix;
+          ragenix = self.packages.${prev.stdenv.hostSystem.system}.ragenix;
           agenix = ragenix;
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -352,7 +352,7 @@
 
         # Overlay to add ragenix and replace agenix
         overlay = final: prev: rec {
-          ragenix = self.packages.${prev.stdenv.hostSystem.system}.ragenix;
+          ragenix = self.packages.${prev.stdenv.hostPlatform.system}.ragenix;
           agenix = ragenix;
         };
       }


### PR DESCRIPTION
`system` is an alias of `stdenv.hostPlatform.system` and using it will cause
evaluation to fail for everyone who disables aliases.

The flake should be using the full path to the attribute instead, which this PR
does.
