### PR TITLE
Flake: disable nixpkgs aliases

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 , installShellFiles
 , libiconv
 , makeWrapper
-, nixFlakes
+, nix
 , openssl
 , pkg-config
 , plugins ? [ ]
@@ -74,7 +74,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # Absolute path to the `nix` binary, used in `build.rs`
-  RAGENIX_NIX_BIN_PATH = "${nixFlakes}/bin/nix";
+  RAGENIX_NIX_BIN_PATH = "${nix}/bin/nix";
 
   # Run the tests without the "recursive-nix" feature to allow
   # building the package without having a recursive-nix-enabled Nix.

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
       pkgsFor = system: import nixpkgs {
         inherit system;
         overlays = [ rust-overlay.overlay self.overlay ];
+        config = { allowAliases = false; };
       };
     in
     recursiveMerge [
@@ -222,7 +223,7 @@
               darwin.Security
             ];
 
-            RAGENIX_NIX_BIN_PATH = "${pkgs.nixFlakes}/bin/nix";
+            RAGENIX_NIX_BIN_PATH = "${pkgs.nix}/bin/nix";
 
             RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
 
@@ -238,7 +239,9 @@
       (eachLinuxSystem (pkgs: {
         checks.nixos-module =
           let
-            pythonTest = import ("${nixpkgs}/nixos/lib/testing-python.nix") { inherit (pkgs) system; };
+            pythonTest = import ("${nixpkgs}/nixos/lib/testing-python.nix") {
+              inherit (pkgs.stdenv.hostPlatform) system;
+            };
             secretsConfig = import ./example/secrets-configuration.nix;
             secretPath = "/run/agenix/github-runner.token";
             ageIdentitiesConfig = { lib, ... }: {


### PR DESCRIPTION
Make sure the `ragenix` flake evaluates with `nixpkgs.config.allowAliases = false`.

No need to use the `nixFlakes` alias anymore (it's a reference to stable today).

Follow-up to #90.
