### PR TITLE
Update flake inputs and Cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,9 +917,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jsonschema"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af26b80b2c3d68bd5b68d36160573f9d497cfe1cc81645a6820deed349d54f02"
+checksum = "4ebd40599e7f1230ce296f73b88c022b98ed66689f97eaa54bbeadc337a2ffa6"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "assert_cmd"
@@ -164,9 +164,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
@@ -344,15 +344,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
@@ -360,11 +360,20 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6f3613c0a3cddfd78b41b10203eb322cb29b600cbdf808a7d3db95691b8e25"
+checksum = "1506b87ee866f7a53a5131f7b31fba656170d797e873d0609884cfd56b8bbda8"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -908,9 +917,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jsonschema"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9278850dcb3a55938dfc2843701c5e26746d1679310bf5480c01d1a1cefe37"
+checksum = "af26b80b2c3d68bd5b68d36160573f9d497cfe1cc81645a6820deed349d54f02"
 dependencies = [
  "ahash",
  "anyhow",
@@ -954,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "libm"
@@ -1003,12 +1012,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1150,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -1174,15 +1182,12 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "owo-colors"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e72e30578e0d0993c8ae20823dd9cff2bc5517d2f586a8aef462a581e8a03eb"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
 
 [[package]]
 name = "parking_lot"
@@ -1371,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1545,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "6.3.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40377bff8cceee81e28ddb73ac97f5c2856ce5522f0b260b763f434cdfae602"
+checksum = "9a17e5ac65b318f397182ae94e532da0ba56b88dd1200b774715d36c4943b1c3"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -1569,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad22c7226e4829104deab21df575e995bfbc4adfad13a595e387477f238c1aec"
+checksum = "756feca3afcbb1487a1d01f4ecd94cf8ec98ea074c55a69e7136d29fb6166029"
 dependencies = [
  "sha2 0.9.9",
  "walkdir 2.3.2",
@@ -1868,9 +1873,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
@@ -1858,9 +1858,9 @@ checksum = "29738eedb4388d9ea620eeab9384884fc3f06f586a2eddb56bedc5885126c7c1"
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1916,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ age = { version = "^0.7", default-features = false, features = [ "cli-common", "
 clap = { version = "^3.0", features = [ "cargo", "env" ] }
 color-eyre = { version = "^0.6", default-features = false, features = [ "track-caller" ] }
 home = "^0.5"
-jsonschema = { version = "^0.15", default-features = false }
+jsonschema = { version = "^0.16", default-features = false }
 serde = "^1.0"
 serde_json = "^1.0"
 sha2 = "^0.10"

--- a/docs/ragenix.1
+++ b/docs/ragenix.1
@@ -1,196 +1,127 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "RAGENIX" "1" "January 2022" "" ""
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "RAGENIX" "1" "January 2022" ""
 .SH "NAME"
 \fBragenix\fR \- age\-encrypted secrets for Nix
-.
 .SH "SYNOPSIS"
-\fBragenix\fR [\fB\-\-rules\fR \fIPATH\fR=\./secrets\.nix] [\fB\-i\fR \fIPATH\fR]\.\.\. (\fB\-e\fR \fIPATH\fR | \fB\-r\fR)
-.
+\fBragenix\fR [\fB\-\-rules\fR \fIPATH\fR=\./secrets\.nix] [\fB\-i\fR \fIPATH\fR]\|\.\|\.\|\. (\fB\-e\fR \fIPATH\fR | \fB\-r\fR)
 .br
 \fBragenix\fR \fB\-e\fR \fIPATH\fR
-.
 .br
 \fBragenix\fR \fB\-r\fR
-.
 .br
-.
 .SH "DESCRIPTION"
 \fBragenix\fR encrypts secrets defined in a Nix configuration expression using \fBage(1)\fR\. It is safe to publicly expose the resulting age\-encrypted files, e\.g\., by checking them into version control or copying them to the world\-readable Nix store\.
-.
 .SH "OPTIONS"
-.
 .TP
 \fB\-e\fR, \fB\-\-edit\fR \fIPATH\fR
 Decrypt the file at \fIPATH\fR and open it for editing\. If the \fIPATH\fR does not exist yet, \fBragenix\fR opens an empty file for editing\. In any case, the given \fIPATH\fR has to match a rule as configured in the file given to the \fB\-\-rules\fR option\. After editing, \fBragenix\fR encrypts the updated contents and replaces the original file\.
-.
 .IP
 If the \fB\-\-identity\fR option is not given, \fBragenix\fR tries to decrypt \fIPATH\fR with the default SSH private keys\. See \fB\-\-identity\fR for details\.
-.
 .IP
 The encrypted file always uses an ASCII\-armored format\.
-.
 .IP
 \fBragenix\fR writes the decrypted plaintext contents of the secret at \fIPATH\fR to a temporary file which is only accessible by the calling user\. After editing, \fBragenix\fR deletes the file, making it inaccessible after \fBragenix\fR exits\.
-.
 .TP
 \fB\-\-editor\fR \fIPROGRAM\fR
 Use the given \fIPROGRAM\fR to open the decrypted file for editing\. Defaults to the \fBEDITOR\fR environment variable\.
-.
 .IP
 \fIPROGRAM\fR may denote an absolute binary path or a binary relative to the \fBPATH\fR environment variable\. \fBragenix\fR assumes \fIPROGRAM\fR accepts the absolute path to the decrypted age secret file as its first argument\.
-.
 .IP
 Giving the special token \fB\-\fR as a \fIPROGRAM\fR causes \fBragenix\fR to read from standard input\. In this case, \fBragenix\fR stream\-encrypts data from standard input only and does not open the file for editing\.
-.
 .TP
 \fB\-r\fR, \fB\-\-rekey\fR
 Decrypt all secrets given in the rules configuration file and encrypt them with the defined public keys\. If a secret file does not exist yet, it is ignored\. This option is useful to grant a new recipient access to one or multiple secrets\.
-.
 .IP
 If the \fB\-\-identity\fR option is not given, \fBragenix\fR tries to decrypt \fIPATH\fR with the default SSH private keys\. See \fB\-\-identity\fR for details\.
-.
 .IP
 When rekeying, \fBragenix\fR does not write any plaintext data to disk; all processing happens in\-memory\.
-.
 .SH "COMMON OPTIONS"
-.
 .TP
 \fB\-\-rules\fR \fIPATH\fR
 Path to a file containing a Nix expression which maps age\-encrypted secret files to the public keys of recipients who should be able to decrypt them\. Each defined secret file string is considered relative to the parent directory of the rules file\. See the \fIEXAMPLES\fR section for a simple rules configuration\.
-.
 .IP
 If omitted, \fBragenix\fR reads the content of the \fBRULES\fR environment variable\. If the environment variable is also unset, \fBragenix\fR tries opening the file \fBsecrets\.nix\fR in the current working directory\.
-.
 .TP
 \fB\-i\fR, \fB\-\-identity\fR \fIPATH\fR
 Decrypt using the identities at \fIPATH\fR\.
-.
 .IP
 This option can be repeated\. Additionally, \fBragenix\fR uses the default Ed25519 and RSA SSH authentication identities at ~/\.ssh/id_ed25519 and ~/\.ssh/id_rsa, respectively\. Identities given explicitly take precedence over the default SSH identities\. If no identities are given, \fBragenix\fR tries using the default SSH identities only\.
-.
 .IP
 Passphrase\-encrypted age identities and passphrase\-encryted SSH identities are supported\. Currently, however, it is necessary to enter the passphrase of an SSH identity for each file to decrypt\. This may result in poor usability, particularly when using the \fB\-\-rekey\fR option\.
-.
 .IP
 For further details regarding this option also refer to \fBage(1)\fR\.
-.
 .SH "FURTHER OPTIONS"
-.
 .TP
 \fB\-s\fR, \fB\-\-schema\fR
 Print the JSON schema the Nix configuration rules have to conform to and exit\. Useful for consumption by third\-party applications\.
-.
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Print additional information during program execution\.
-.
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Print the version and exit\.
-.
 .SH "PLUGINS"
 \fBragenix\fR also supports \fBage\fR plugins\. If the plugin binaries are present in \fBPATH\fR, \fBragenix\fR picks them up as needed\.
-.
 .P
 Additionally, \fBragenix\fR supports adding plugins to its derviation to make them always available to \fBragenix\fR\. Use the \fBplugins\fR argument of the derivation to wrap the \fBragenix\fR binary with a \fBPATH\fR extended by the given plugin derivations\. Matching plugin binaries which are part of \fBPATH\fR when invoking \fBragenix\fR are preferred\. See the \fIEXAMPLES\fR section for an example\.
-.
 .SH "EXAMPLES"
 A basic Nix configuration rules file (typically named secrets\.nix) which defines a secret file secret\.txt\.age which should be encrypted to an age and an SSH recipient\. \fBragenix\fR looks for secret\.txt\.age relative to \./secrets/:
-.
 .IP "" 4
-.
 .nf
-
 $ cat \./secrets/secrets\.nix
 {
   "secret\.txt\.age"\.publicKeys = [
     "age1g4eapz2lkdvrevsg443yx8rhxklhyz4sa8w0jdfyh8sgx3azhftsz8zu07"
-    "ssh\-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrb9ne3nZjw6DW[\.\.\.]8h/Zoa"
+    "ssh\-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrb9ne3nZjw6DW[\|\.\|\.\|\.]8h/Zoa"
   ];
 }
 $ file \./secrets/secret\.txt\.age
-\./secrets/secret\.txt\.age: ASCII text
-.
+\&\./secrets/secret\.txt\.age: ASCII text
 .fi
-.
 .IP "" 0
-.
 .P
 Edit the secret file secret\.txt\.age in the default editor while using the default SSH Ed25519 identity at ~/\.ssh/id_ed25519 with a rules configuration file different from \./secrets\.nix:
-.
 .IP "" 4
-.
 .nf
-
 $ ls ~/\.ssh/
 id_ed25519  id_ed25519\.pub
 $ ls /var/lib/secrets/
 rules\.nix secret\.txt\.age
 $ ragenix \-\-rules /var/lib/secrets/rules\.nix \-e secret\.txt\.age
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Rekey all secrets given in \./secrets\.nix with the age identity ~/\.age/ragenix\.key:
-.
 .IP "" 4
-.
 .nf
-
 $ ragenix \-i ~/\.age/ragenix\.key \-r
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Create/edit a secret from the system clipboard (on macOS):
-.
 .IP "" 4
-.
 .nf
-
 $ pbpaste | ragenix \-\-editor \- \-e secret\.txt\.age
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Use \fB\-\-editor\fR to generate an SSH Ed25519 private key:
-.
 .IP "" 4
-.
 .nf
-
 $ ragenix \-\-editor \'ssh\-keygen \-q \-N "" \-t ed25519 \-f\' \-e ssh_host_key\.age
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Make the \fBage\fR YubiKey plugin available to \fBragenix\fR:
-.
 .IP "" 4
-.
 .nf
-
 $ cat myragenix\.nix
 { ragenix, age\-plugin\-yubikey }:
 ragenix\.override { plugins = [ age\-plugin\-yubikey ]; }
-.
 .fi
-.
 .IP "" 0
-.
 .SH "SEE ALSO"
 age(1), age\-keygen(1)
-.
 .SH "AUTHORS"
 Vincent Haupert \fImail@vincent\-haupert\.de\fR

--- a/docs/ragenix.1.html
+++ b/docs/ragenix.1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>ragenix(1) - age-encrypted secrets for Nix</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -71,16 +71,17 @@
     <li class='tr'>ragenix(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>ragenix</code> - <span class="man-whatis">age-encrypted secrets for Nix</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>ragenix</code> [<code>--rules</code> <var>PATH</var>=./secrets.nix] [<code>-i</code> <var>PATH</var>]... (<code>-e</code> <var>PATH</var> | <code>-r</code>)<br />
-<code>ragenix</code> <code>-e</code> <var>PATH</var><br />
-<code>ragenix</code> <code>-r</code><br /></p>
+<p><code>ragenix</code> [<code>--rules</code> <var>PATH</var>=./secrets.nix] [<code>-i</code> <var>PATH</var>]... (<code>-e</code> <var>PATH</var> | <code>-r</code>)<br>
+<code>ragenix</code> <code>-e</code> <var>PATH</var><br>
+<code>ragenix</code> <code>-r</code><br></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -92,82 +93,108 @@ store.</p>
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <dl>
-<dt><code>-e</code>, <code>--edit</code> <var>PATH</var></dt><dd><p>  Decrypt the file at <var>PATH</var> and open it for editing. If the <var>PATH</var> does not
+<dt>
+<code>-e</code>, <code>--edit</code> <var>PATH</var>
+</dt>
+<dd>  Decrypt the file at <var>PATH</var> and open it for editing. If the <var>PATH</var> does not
   exist yet, <code>ragenix</code> opens an empty file for editing. In any case, the
   given <var>PATH</var> has to match a rule as configured in the file given to the
   <code>--rules</code> option. After editing, <code>ragenix</code> encrypts the updated contents
-  and replaces the original file.</p>
+  and replaces the original file.
 
-<p>  If the <code>--identity</code> option is not given, <code>ragenix</code> tries to decrypt <var>PATH</var>
+    <p>If the <code>--identity</code> option is not given, <code>ragenix</code> tries to decrypt <var>PATH</var>
   with the default SSH private keys. See <code>--identity</code> for details.</p>
 
-<p>  The encrypted file always uses an ASCII-armored format.</p>
+    <p>The encrypted file always uses an ASCII-armored format.</p>
 
-<p>  <code>ragenix</code> writes the decrypted plaintext contents of the secret at <var>PATH</var>
+    <p><code>ragenix</code> writes the decrypted plaintext contents of the secret at <var>PATH</var>
   to a temporary file which is only accessible by the calling user. After
   editing, <code>ragenix</code> deletes the file, making it inaccessible after <code>ragenix</code>
-  exits.</p></dd>
-<dt><code>--editor</code> <var>PROGRAM</var></dt><dd><p>  Use the given <var>PROGRAM</var> to open the decrypted file for editing. Defaults to
-  the <code>EDITOR</code> environment variable.</p>
+  exits.</p>
+</dd>
+<dt>
+<code>--editor</code> <var>PROGRAM</var>
+</dt>
+<dd>  Use the given <var>PROGRAM</var> to open the decrypted file for editing. Defaults to
+  the <code>EDITOR</code> environment variable.
 
-<p>  <var>PROGRAM</var> may denote an absolute binary path or a binary relative to the
+    <p><var>PROGRAM</var> may denote an absolute binary path or a binary relative to the
   <code>PATH</code> environment variable. <code>ragenix</code> assumes <var>PROGRAM</var> accepts the
   absolute path to the decrypted age secret file as its first argument.</p>
 
-<p>  Giving the special token <code>-</code> as a <var>PROGRAM</var> causes <code>ragenix</code> to read from
+    <p>Giving the special token <code>-</code> as a <var>PROGRAM</var> causes <code>ragenix</code> to read from
   standard input. In this case, <code>ragenix</code> stream-encrypts data from standard
-  input only and does not open the file for editing.</p></dd>
-<dt><code>-r</code>, <code>--rekey</code></dt><dd><p>  Decrypt all secrets given in the rules configuration file and encrypt them
+  input only and does not open the file for editing.</p>
+</dd>
+<dt>
+<code>-r</code>, <code>--rekey</code>
+</dt>
+<dd>  Decrypt all secrets given in the rules configuration file and encrypt them
   with the defined public keys. If a secret file does not exist yet, it is
   ignored. This option is useful to grant a new recipient access to one or
-  multiple secrets.</p>
+  multiple secrets.
 
-<p>  If the <code>--identity</code> option is not given, <code>ragenix</code> tries to decrypt <var>PATH</var>
+    <p>If the <code>--identity</code> option is not given, <code>ragenix</code> tries to decrypt <var>PATH</var>
   with the default SSH private keys. See <code>--identity</code> for details.</p>
 
-<p>  When rekeying, <code>ragenix</code> does not write any plaintext data to disk; all
-  processing happens in-memory.</p></dd>
+    <p>When rekeying, <code>ragenix</code> does not write any plaintext data to disk; all
+  processing happens in-memory.</p>
+</dd>
 </dl>
-
 
 <h2 id="COMMON-OPTIONS">COMMON OPTIONS</h2>
 
 <dl>
-<dt><code>--rules</code> <var>PATH</var></dt><dd><p>  Path to a file containing a Nix expression which maps age-encrypted secret
+<dt>
+<code>--rules</code> <var>PATH</var>
+</dt>
+<dd>  Path to a file containing a Nix expression which maps age-encrypted secret
   files to the public keys of recipients who should be able to decrypt them.
   Each defined secret file string is considered relative to the parent
   directory of the rules file. See the <a href="#EXAMPLES" title="EXAMPLES" data-bare-link="true">EXAMPLES</a> section for a
-  simple rules configuration.</p>
+  simple rules configuration.
 
-<p>  If omitted, <code>ragenix</code> reads the content of the <code>RULES</code> environment
+    <p>If omitted, <code>ragenix</code> reads the content of the <code>RULES</code> environment
   variable. If the environment variable is also unset, <code>ragenix</code> tries
-  opening the file <code>secrets.nix</code> in the current working directory.</p></dd>
-<dt><code>-i</code>, <code>--identity</code> <var>PATH</var></dt><dd><p>  Decrypt using the identities at <var>PATH</var>.</p>
+  opening the file <code>secrets.nix</code> in the current working directory.</p>
+</dd>
+<dt>
+<code>-i</code>, <code>--identity</code> <var>PATH</var>
+</dt>
+<dd>  Decrypt using the identities at <var>PATH</var>.
 
-<p>  This option can be repeated. Additionally, <code>ragenix</code> uses the default
+    <p>This option can be repeated. Additionally, <code>ragenix</code> uses the default
   Ed25519 and RSA SSH authentication identities at ~/.ssh/id_ed25519 and
   ~/.ssh/id_rsa, respectively. Identities given explicitly take precedence
   over the default SSH identities. If no identities are given, <code>ragenix</code>
   tries using the default SSH identities only.</p>
 
-<p>  Passphrase-encrypted age identities and passphrase-encryted SSH identities
+    <p>Passphrase-encrypted age identities and passphrase-encryted SSH identities
   are supported. Currently, however, it is necessary to enter the passphrase
   of an SSH identity for each file to decrypt. This may result in poor
   usability, particularly when using the <code>--rekey</code> option.</p>
 
-<p>  For further details regarding this option also refer to <code>age(1)</code>.</p></dd>
+    <p>For further details regarding this option also refer to <code>age(1)</code>.</p>
+</dd>
 </dl>
-
 
 <h2 id="FURTHER-OPTIONS">FURTHER OPTIONS</h2>
 
 <dl>
-<dt><code>-s</code>, <code>--schema</code></dt><dd><p>  Print the JSON schema the Nix configuration rules have to conform to and
-  exit. Useful for consumption by third-party applications.</p></dd>
-<dt><code>-v</code>, <code>--verbose</code></dt><dd><p>  Print additional information during program execution.</p></dd>
-<dt><code>-V</code>, <code>--version</code></dt><dd><p>  Print the version and exit.</p></dd>
+<dt>
+<code>-s</code>, <code>--schema</code>
+</dt>
+<dd>  Print the JSON schema the Nix configuration rules have to conform to and
+  exit. Useful for consumption by third-party applications.</dd>
+<dt>
+<code>-v</code>, <code>--verbose</code>
+</dt>
+<dd>  Print additional information during program execution.</dd>
+<dt>
+<code>-V</code>, <code>--version</code>
+</dt>
+<dd>  Print the version and exit.</dd>
 </dl>
-
 
 <h2 id="PLUGINS">PLUGINS</h2>
 
@@ -237,8 +264,7 @@ ragenix.override { plugins = [ age-plugin-yubikey ]; }
 
 <h2 id="AUTHORS">AUTHORS</h2>
 
-<p>Vincent Haupert <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#109;&#97;&#105;&#108;&#64;&#118;&#105;&#110;&#99;&#101;&#110;&#116;&#45;&#104;&#97;&#117;&#112;&#101;&#114;&#116;&#46;&#100;&#101;" data-bare-link="true">&#109;&#97;&#105;&#108;&#64;&#118;&#105;&#110;&#99;&#101;&#110;&#116;&#45;&#104;&#97;&#117;&#112;&#101;&#114;&#116;&#46;&#100;&#101;</a></p>
-
+<p>Vincent Haupert <a href="mailto:mail@vincent-haupert.de" data-bare-link="true">mail@vincent-haupert.de</a></p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650701402,
-        "narHash": "sha256-XKfstdtqDg+O+gNBx1yGVKWIhLgfEDg/e2lvJSsp9vU=",
+        "lastModified": 1650920067,
+        "narHash": "sha256-iV+7zkBZsHiy4epfcyoiW8lRXdjZXq6h8RfNcaua4Fc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc41b01dd7a9fdffd32d9b03806798797532a5fe",
+        "rev": "6a323903ad07de6680169bb0423c5cea9db41d82",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650681299,
-        "narHash": "sha256-JNvHHeeXDl3UnjWolMSbH2sWvhAYPfAutL815kZ6vFs=",
+        "lastModified": 1651027770,
+        "narHash": "sha256-L1tl7tezuIkDUgMkcDpg8zkfzPsysp2BMb4a7pT439s=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d10f36b093459eb71ddcfedbab538c1ae3dfebb2",
+        "rev": "628301be224ea8822f043fe9de9299dbcb356a3c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1648297722,
-        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649408932,
-        "narHash": "sha256-JhTW1OtS5fACcRXLqcTTQyYO5vLkO+bceCqeRms13SY=",
+        "lastModified": 1650701402,
+        "narHash": "sha256-XKfstdtqDg+O+gNBx1yGVKWIhLgfEDg/e2lvJSsp9vU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "42948b300670223ca8286aaf916bc381f66a5313",
+        "rev": "bc41b01dd7a9fdffd32d9b03806798797532a5fe",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649471450,
-        "narHash": "sha256-To2sEKvI5YhE1VqEdQKLrTW1sbq+/V8i+2ZLKR3OouI=",
+        "lastModified": 1650681299,
+        "narHash": "sha256-JNvHHeeXDl3UnjWolMSbH2sWvhAYPfAutL815kZ6vFs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4579190c4c427b8350c662417c26254589dfe658",
+        "rev": "d10f36b093459eb71ddcfedbab538c1ae3dfebb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updated Flake dependencies through `nix flake update`.

```
Resolved URL: git+file:///home/runner/work/ragenix/ragenix?shallow=1
Locked URL: git+file:///home/runner/work/ragenix/ragenix?ref=main&rev=5138a6796b20e949f834701cd46538776ae3e640&shallow=1
Description: A rust drop-in replacement for agenix
Path: /nix/store/l48qjlmgwsv7zs8x1qy2z1snv8ikb51l-source
Revision: 5138a6796b20e949f834701cd46538776ae3e640
Last modified: 2022-04-24 02:30:38
Inputs:
├───agenix: github:ryantm/agenix/0d5e59ed645e4c7b60174bc6f6aac6a203dc0b01
│ └───nixpkgs follows input 'nixpkgs'
├───flake-utils: github:numtide/flake-utils/a4b154ebbdc88c8498a5c7b01589addc9e9cb678
├───nixpkgs: github:nixos/nixpkgs/bc41b01dd7a9fdffd32d9b03806798797532a5fe
└───rust-overlay: github:oxalica/rust-overlay/d10f36b093459eb71ddcfedbab538c1ae3dfebb2
 ├───flake-utils follows input 'flake-utils'
 └───nixpkgs follows input 'nixpkgs'
```

Updated Cargo dependencies through `cargo update`.

Dependency status of `main` prior to this PR:
[![dependency status](https://deps.rs/repo/github/yaxitech/ragenix/status.svg)
](https://deps.rs/repo/github/yaxitech/ragenix)