### PR TITLE
Remove calls to obsolete header function

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -43,10 +43,10 @@ rustPlatform.buildRustPackage {
   preBuildPhases = [ "codeStyleConformanceCheck" ];
 
   codeStyleConformanceCheck = ''
-    header "Checking Rust code formatting"
+    echo "Checking Rust code formatting"
     cargo fmt -- --check
 
-    header "Running clippy"
+    echo "Running clippy"
     # clippy - use same checkType as check-phase to avoid double building
     if [ "''${cargoCheckType}" != "debug" ]; then
         cargoCheckProfileFlag="--''${cargoCheckType}"

--- a/flake.nix
+++ b/flake.nix
@@ -189,18 +189,18 @@
             } ''
             set -euo pipefail
 
-            header "Generate roff and HTML manpage"
+            echo "Generate roff and HTML manpage"
             ln -s ${self}/docs/ragenix.1.ronn .
             ronn ragenix.1.ronn
 
-            header "roff: strip date"
+            echo "roff: strip date"
             tail -n '+5' ${self}/docs/ragenix.1 > ragenix.1.old
             tail -n '+5'              ragenix.1 > ragenix.1.new
 
             diff -u ragenix.1.{old,new} > diff \
               || (printf "roff: error, not up-to-date:\n\n%s\n" "$(cat diff)" >&2 && exit 1)
 
-            header "html: strip date"
+            echo "html: strip date"
             grep -v "<li class='tc'>" ${self}/docs/ragenix.1.html > ragenix.1.html.old
             grep -v "<li class='tc'>"              ragenix.1.html > ragenix.1.html.new
 


### PR DESCRIPTION
The `header` function was recently removed from the Nixpkgs stdenv after having been deprecated in 2017
(https://github.com/NixOS/nixpkgs/commit/856f3a46b2f64d4481ced392e1ebc86f09551521). It's used in a few places here, which prevents building ragenix on the latest Nixpkgs. In the commit removing `header`, all remaining uses were replaced with `echo`