### PR TITLE
Get format in line with clippy 1.67

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,10 +21,7 @@ fn main() -> Result<(), Error> {
     println!("cargo:rustc-env=RAGENIX_NIX_BIN_PATH={nix_bin_path}");
 
     // Make the paths to the shell completion files available as environment variables
-    let outdir = match env::var_os("OUT_DIR") {
-        None => return Ok(()),
-        Some(outdir) => outdir,
-    };
+    let Some(outdir) = env::var_os("OUT_DIR") else { return Ok(()) };
 
     let mut app = build();
     app.set_bin_name(crate_name!());

--- a/tests/ragenix.rs
+++ b/tests/ragenix.rs
@@ -425,10 +425,7 @@ fn fails_for_invalid_recipient() -> Result<()> {
 
     assert
         .failure()
-        .stderr(predicate::str::contains(format!(
-            "Invalid recipient: {}",
-            invalid_key
-        )))
+        .stderr(predicate::str::contains(format!("Invalid recipient: {invalid_key}")))
         .stderr(predicate::str::contains(
             "Make sure you use an ssh-ed25519, ssh-rsa or an X25519 public key, alternatively install an age plugin which supports your key",
         ));


### PR DESCRIPTION
Latest clippy adds a couple of new new lint rules [0], some of which are breaking when building ragenix. Specifically:

- `manual_let_else` [1]
- `uninlined-format-args` [2]

This commit addresses the offending code.

[0] https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-167
[1] https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else
[2] https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args