### PR TITLE
Use crane

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,5 @@ jobs:
         with:
           name: wurzelpfropf
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN_PUBLIC }}'
-      - name: 'Check flake evaluates'
-        run: nix flake check --no-build .
       - name: 'Run all checks'
         run: nix flake check -L .

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ rustPlatform
+{ craneLib
 , lib
 , stdenv
 , darwin
@@ -7,79 +7,46 @@
 , nix
 , openssl
 , pkg-config
-, self ? ./.
 , plugins ? [ ]
 }:
 let
-  # Filter out VCS files and files unrelated to the Rust ragenix package
-  filterRustSource = src: with lib; cleanSourceWith {
-    filter = cleanSourceFilter;
-    src = cleanSourceWith {
-      inherit src;
-      filter = name: type:
-        let pathWithoutPrefix = removePrefix (toString src) name; in
-          ! (
-            hasPrefix "/.github" pathWithoutPrefix ||
-            pathWithoutPrefix == "/.gitignore" ||
-            pathWithoutPrefix == "/LICENSE" ||
-            pathWithoutPrefix == "/README.md" ||
-            pathWithoutPrefix == "/docs/ragenix.1.html" ||
-            pathWithoutPrefix == "/docs/ragenix.1.ronn" ||
-            pathWithoutPrefix == "/flake.lock" ||
-            pathWithoutPrefix == "/flake.nix"
-          );
+  commonArgs = {
+    src = lib.cleanSourceWith rec {
+      src = craneLib.path ./.;
+      filter = path: type:
+        let pathWithoutPrefix = lib.removePrefix (toString src) path; in
+        lib.hasPrefix "/docs/" pathWithoutPrefix ||
+        lib.hasPrefix "/example/" pathWithoutPrefix ||
+        lib.hasPrefix "/src/" pathWithoutPrefix ||
+        craneLib.filterCargoSources path type;
     };
+
+    # build dependencies
+    nativeBuildInputs = [
+      pkg-config
+      installShellFiles
+    ] ++ lib.optionals (plugins != [ ]) [
+      makeWrapper
+    ];
+
+    # runtime dependencies
+    buildInputs = [
+      openssl
+    ] ++ lib.optionals stdenv.isDarwin [
+      darwin.Security
+    ];
+
+    # Absolute path to the `nix` binary, used in `build.rs`
+    RAGENIX_NIX_BIN_PATH = lib.getExe nix;
   };
-  rustSource = filterRustSource self;
-  cargoTOML = with builtins; fromTOML (readFile ./Cargo.toml);
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 in
-rustPlatform.buildRustPackage {
-  pname = cargoTOML.package.name;
-  version = cargoTOML.package.version;
-  src = rustSource;
-
-  cargoLock.lockFile = ./Cargo.lock;
-
-  preBuildPhases = [ "codeStyleConformanceCheck" ];
-
-  codeStyleConformanceCheck = ''
-    echo "Checking Rust code formatting"
-    cargo fmt -- --check
-
-    echo "Running clippy"
-    # clippy - use same checkType as check-phase to avoid double building
-    if [ "''${cargoCheckType}" != "debug" ]; then
-        cargoCheckProfileFlag="--''${cargoCheckType}"
-    fi
-    argstr="''${cargoCheckProfileFlag} --workspace --all-features --tests "
-    cargo clippy -j $NIX_BUILD_CORES \
-       $argstr -- \
-       -D clippy::pedantic \
-       -D warnings
-  '';
-
-  # build dependencies
-  nativeBuildInputs = [
-    pkg-config
-    installShellFiles
-  ] ++ lib.optionals (plugins != [ ]) [
-    makeWrapper
-  ];
-
-  # runtime dependencies
-  buildInputs = [
-    openssl
-  ] ++ lib.optionals stdenv.isDarwin [
-    darwin.Security
-  ];
-
-  # Absolute path to the `nix` binary, used in `build.rs`
-  RAGENIX_NIX_BIN_PATH = "${nix}/bin/nix";
+craneLib.buildPackage (commonArgs // {
+  inherit cargoArtifacts;
 
   # Run the tests without the "recursive-nix" feature to allow
   # building the package without having a recursive-nix-enabled Nix.
-  checkNoDefaultFeatures = true;
-  doCheck = true;
+  cargoTestExtraArgs = "--no-default-features";
 
   postInstall = ''
     set -euo pipefail
@@ -88,12 +55,13 @@ rustPlatform.buildRustPackage {
     ln -sr "$out/bin/ragenix" "$out/bin/agenix"
 
     # Stdout of build.rs
-    buildOut=$(find "$tmpDir/build" -type f -regex ".*\/ragenix-[a-z0-9]+\/output")
+    buildOut=$(grep -m 1 -Rl 'RAGENIX_COMPLETIONS_BASH=/' target/ | head -n 1)
+    printf "found build script output at %s\n" "$buildOut"
 
     set +u # required due to `installShellCompletion`'s implementation
-    installShellCompletion --bash "$(grep -oP 'RAGENIX_COMPLETIONS_BASH=\K.*' $buildOut)"
-    installShellCompletion --zsh  "$(grep -oP 'RAGENIX_COMPLETIONS_ZSH=\K.*' $buildOut)"
-    installShellCompletion --fish "$(grep -oP 'RAGENIX_COMPLETIONS_FISH=\K.*' $buildOut)"
+    installShellCompletion --bash "$(grep -oP 'RAGENIX_COMPLETIONS_BASH=\K.+' "$buildOut")"
+    installShellCompletion --zsh  "$(grep -oP 'RAGENIX_COMPLETIONS_ZSH=\K.+'  "$buildOut")"
+    installShellCompletion --fish "$(grep -oP 'RAGENIX_COMPLETIONS_FISH=\K.+' "$buildOut")"
 
     installManPage docs/ragenix.1
   '';
@@ -102,4 +70,6 @@ rustPlatform.buildRustPackage {
   postFixup = lib.optionalString (plugins != [ ]) ''
     wrapProgram "$out/bin/ragenix" --suffix PATH : ${lib.strings.makeBinPath plugins}
   '';
-}
+
+  passthru.cargoArtifacts = cargoArtifacts;
+})

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,33 @@
         "type": "github"
       }
     },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1681177078,
+        "narHash": "sha256-ZNIjBDou2GOabcpctiQykEQVkI8BDwk7TyvlWlI4myE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0c9f468ff00576577d83f5019a66c557ede5acf6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -40,6 +67,22 @@
         "owner": "lnl7",
         "ref": "master",
         "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -77,6 +120,7 @@
     "root": {
       "inputs": {
         "agenix": "agenix",
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -238,7 +238,7 @@
             rust-analyzer
           ];
 
-          RAGENIX_NIX_BIN_PATH = "${pkgs.nix}/bin/nix";
+          RAGENIX_NIX_BIN_PATH = lib.getExe pkgs.nix;
 
           RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,15 +9,21 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.rust-overlay.follows = "rust-overlay";
+    };
     agenix = {
       url = "github:ryantm/agenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, agenix }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane, agenix }:
     let
-      cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      cargoTOML = lib.importTOML ./Cargo.toml;
       name = cargoTOML.package.name;
 
       lib = nixpkgs.lib;
@@ -32,7 +38,14 @@
 
       pkgsFor = system: import nixpkgs {
         inherit system;
-        overlays = [ rust-overlay.overlays.default self.overlays.default ];
+        overlays = [
+          rust-overlay.overlays.default
+          self.overlays.default
+          (final: prev: {
+            rustToolchain = final.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+            craneLib = (crane.mkLib prev).overrideToolchain final.rustToolchain;
+          })
+        ];
         config = { allowAliases = false; };
       };
     in
@@ -40,197 +53,200 @@
       #
       # COMMON OUTPUTS FOR ALL SYSTEMS
       #
-      (eachDefaultSystem (pkgs:
-        let
-          rust = pkgs.rust-bin.fromRustupToolchainFile "${self}/rust-toolchain";
-        in
-        rec {
-          # `nix build`
-          packages.${name} = pkgs.callPackage "${self}/default.nix" {
-            inherit self;
-            rustPlatform = pkgs.makeRustPlatform {
-              cargo = rust;
-              rustc = rust;
-            };
-          };
-          packages.default = packages.${name};
-          defaultPackage = lib.warnIf (builtins.compareVersions builtins.nixVersion "2.7" >= 0)
-            "ragenix's flake output `defaultPackage` is deprecated in favor of `packages.default` for Nix >= 2.7"
-            packages.default;
+      (eachDefaultSystem (pkgs: rec {
+        # `nix build`
+        packages.${name} = pkgs.callPackage ./default.nix { };
+        packages.default = packages.${name};
+        defaultPackage = lib.warnIf (builtins.compareVersions builtins.nixVersion "2.7" >= 0)
+          "ragenix's flake output `defaultPackage` is deprecated in favor of `packages.default` for Nix >= 2.7"
+          packages.default;
 
-          # `nix run`
-          apps.${name} = flake-utils.lib.mkApp {
-            drv = packages.${name};
-          };
-          apps.default = apps.${name};
-          defaultApp = lib.warnIf (builtins.compareVersions builtins.nixVersion "2.7" >= 0)
-            "ragenix's flake output `defaultApp` is deprecated in favor of `apps.default` for Nix >= 2.7"
-            apps.default;
+        # `nix run`
+        apps.${name} = flake-utils.lib.mkApp {
+          drv = packages.${name};
+        };
+        apps.default = apps.${name};
+        defaultApp = lib.warnIf (builtins.compareVersions builtins.nixVersion "2.7" >= 0)
+          "ragenix's flake output `defaultApp` is deprecated in favor of `apps.default` for Nix >= 2.7"
+          apps.default;
 
-          # Regenerate the roff and HTML manpages and commit the changes, if any
-          apps.update-manpage = flake-utils.lib.mkApp {
-            drv = pkgs.writeShellApplication {
-              name = "update-manpage";
-              runtimeInputs = with pkgs; [ ronn git ];
-              text = ''
-                ronn docs/ragenix.1.ronn
+        # Regenerate the roff and HTML manpages and commit the changes, if any
+        apps.update-manpage = flake-utils.lib.mkApp {
+          drv = pkgs.writeShellApplication {
+            name = "update-manpage";
+            runtimeInputs = with pkgs; [ ronn git ];
+            text = ''
+              ronn docs/ragenix.1.ronn
 
-                git diff --quiet -- docs/ragenix.1*          || changes=1
-                git diff --staged --quiet -- docs/ragenix.1* || changes=1
+              git diff --quiet -- docs/ragenix.1*          || changes=1
+              git diff --staged --quiet -- docs/ragenix.1* || changes=1
 
-                if [[ -z "''${changes:-}" ]]; then
-                  echo 'No changes to commit'
-                else
-                  echo 'Committing changes'
-                  git commit -m "docs: update manpage" docs/ragenix.1*
-                fi
-              '';
-            };
-          };
-
-          # nix `check`
-          checks.nixpkgs-fmt = pkgs.runCommand "check-nix-format" { } ''
-            ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${self}
-            mkdir $out #sucess
-          '';
-
-          checks.schema = pkgs.runCommand "emit-schema" { } ''
-            set -euo pipefail
-            ${pkgs.ragenix}/bin/ragenix --schema > "$TMPDIR/agenix.schema.json"
-            ${pkgs.diffutils}/bin/diff '${self}/src/ragenix/agenix.schema.json' "$TMPDIR/agenix.schema.json"
-            echo "Schema matches"
-            mkdir "$out"
-          '';
-
-          checks.agenix-symlink = pkgs.runCommand "check-agenix-symlink" { } ''
-            set -euo pipefail
-            agenix="$(readlink -f '${pkgs.ragenix}/bin/agenix')"
-            ragenix="$(readlink -f '${pkgs.ragenix}/bin/ragenix')"
-
-            if [[ "$agenix" == "$ragenix" ]]; then
-              echo "agenix symlinked to ragenix"
-              mkdir $out
-            else
-              echo "agenix doesn't resolve to ragenix"
-              echo "agenix: $agenix"
-              echo "ragenix: $ragenix"
-              exit 1
-            fi
-          '';
-
-          checks.shell-files = pkgs.runCommand "check-shell-files" { } ''
-            set -euo pipefail
-
-            if [[ ! -e "${pkgs.ragenix}/share/bash-completion" ]]; then
-              echo 'Failed to install bash completions'
-            elif [[ ! -e "${pkgs.ragenix}/share/zsh" ]]; then
-              echo 'Failed to install zsh completions'
-            elif [[ ! -e "${pkgs.ragenix}/share/fish" ]]; then
-              echo 'Failed to install fish completions'
-            elif [[ ! -e "${pkgs.ragenix}/share/man/man1/ragenix.1.gz" ]]; then
-              echo 'Failed to install manpage'
-            else
-              echo '${name} shell files installed successfully'
-              mkdir $out
-              exit 0
-            fi
-
-            exit 1
-          '';
-
-          checks.decrypt-with-age = pkgs.runCommand "decrypt-with-age" { } ''
-            set -euo pipefail
-
-            # Required to prevent a panic in the locale_config crate
-            # https://github.com/yaxitech/ragenix/issues/76
-            ${lib.optionalString pkgs.stdenv.isDarwin ''export LANG="en_US.UTF-8"''}
-
-            files=('${self}/example/root.passwd.age' '${self}/example/github-runner.token.age')
-
-            for file in ''${files[@]}; do
-              rage_output="$(${pkgs.rage}/bin/rage -i '${self}/example/keys/id_ed25519' -d "$file")"
-              age_output="$(${pkgs.age}/bin/age    -i '${self}/example/keys/id_ed25519' -d "$file")"
-
-              if [[ "$rage_output" != "$age_output" ]]; then
-                printf 'Decrypted plaintext for %s differs for rage and age' "$file"
-                exit 1
+              if [[ -z "''${changes:-}" ]]; then
+                echo 'No changes to commit'
+              else
+                echo 'Committing changes'
+                git commit -m "docs: update manpage" docs/ragenix.1*
               fi
-            done
-
-            echo "rage and age decryption of examples successful and equal"
-            mkdir $out
-          '';
-
-          checks.metadata = pkgs.runCommand "check-metadata" { } ''
-            set -euo pipefail
-
-            flakeDescription=${lib.escapeShellArg (import "${self}/flake.nix").description}
-            packageDescription=${lib.escapeShellArg cargoTOML.package.description}
-            if [[ "$flakeDescription" != "$packageDescription" ]]; then
-              echo 'The descriptions given in flake.nix and Cargo.toml do not match'
-              exit 1
-            fi
-
-            flakePackageName=${pkgs.ragenix.pname}
-            cargoName=${cargoTOML.package.name}
-            if [[ "$flakePackageName" != "$cargoName" ]]; then
-              echo 'The package name given in flake.nix and Cargo.toml do not match'
-              exit 1
-            fi
-
-            echo 'All metadata checks completed successfully'
-            mkdir $out # success
-          '';
-
-          # Make sure the roff and HTML manpages are up-to-date
-          checks.manpage = pkgs.runCommand "check-manpage"
-            {
-              buildInputs = with pkgs; [ ronn diffutils ];
-            } ''
-            set -euo pipefail
-
-            echo "Generate roff and HTML manpage"
-            ln -s ${self}/docs/ragenix.1.ronn .
-            ronn ragenix.1.ronn
-
-            echo "roff: strip date"
-            tail -n '+5' ${self}/docs/ragenix.1 > ragenix.1.old
-            tail -n '+5'              ragenix.1 > ragenix.1.new
-
-            diff -u ragenix.1.{old,new} > diff \
-              || (printf "roff: error, not up-to-date:\n\n%s\n" "$(cat diff)" >&2 && exit 1)
-
-            echo "html: strip date"
-            grep -v "<li class='tc'>" ${self}/docs/ragenix.1.html > ragenix.1.html.old
-            grep -v "<li class='tc'>"              ragenix.1.html > ragenix.1.html.new
-
-            diff -u ragenix.1.html.{old,new} > diff \
-              || (printf "html: error, not up-to-date:\n\n%s\n" "$(cat diff)" >&2 && exit 1)
-
-            echo 'Manpage is up-to-date'
-            mkdir -p $out
-          '';
-
-          # `nix develop`
-          devShell = pkgs.mkShell {
-            name = "${name}-dev-shell";
-
-            inputsFrom = [ self.packages."${pkgs.stdenv.system}".ragenix ];
-
-            nativeBuildInputs = with pkgs; [
-              ronn
-              rust-analyzer
-            ];
-
-            RAGENIX_NIX_BIN_PATH = "${pkgs.nix}/bin/nix";
-
-            RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
-
-            shellHook = ''
-              export PATH=$PWD/target/debug:$PATH
             '';
           };
-        })
+        };
+
+        # nix `check`
+        checks.clippy = pkgs.craneLib.cargoClippy {
+          inherit (self.packages.${pkgs.stdenv.system}.${name}) src cargoArtifacts;
+          cargoClippyExtraArgs = "--all-targets --tests --examples -- -D clippy::pedantic -D warnings";
+          doInstallCargoArtifacts = false;
+          RAGENIX_NIX_BIN_PATH = lib.getExe pkgs.nix;
+        };
+
+        checks.fmt = pkgs.craneLib.cargoFmt {
+          inherit (self.packages.${pkgs.stdenv.system}.${name}) src cargoArtifacts;
+          doInstallCargoArtifacts = false;
+          RAGENIX_NIX_BIN_PATH = lib.getExe pkgs.nix;
+        };
+
+        checks.nixpkgs-fmt = pkgs.runCommand "check-nix-format" { } ''
+          ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${self}
+          mkdir $out #sucess
+        '';
+
+        checks.schema = pkgs.runCommand "emit-schema" { } ''
+          set -euo pipefail
+          ${pkgs.ragenix}/bin/ragenix --schema > "$TMPDIR/agenix.schema.json"
+          ${pkgs.diffutils}/bin/diff '${self}/src/ragenix/agenix.schema.json' "$TMPDIR/agenix.schema.json"
+          echo "Schema matches"
+          mkdir "$out"
+        '';
+
+        checks.agenix-symlink = pkgs.runCommand "check-agenix-symlink" { } ''
+          set -euo pipefail
+          agenix="$(readlink -f '${pkgs.ragenix}/bin/agenix')"
+          ragenix="$(readlink -f '${pkgs.ragenix}/bin/ragenix')"
+
+          if [[ "$agenix" == "$ragenix" ]]; then
+            echo "agenix symlinked to ragenix"
+            mkdir $out
+          else
+            echo "agenix doesn't resolve to ragenix"
+            echo "agenix: $agenix"
+            echo "ragenix: $ragenix"
+            exit 1
+          fi
+        '';
+
+        checks.shell-files = pkgs.runCommand "check-shell-files" { } ''
+          set -euo pipefail
+
+          if [[ ! -e "${pkgs.ragenix}/share/bash-completion" ]]; then
+            echo 'Failed to install bash completions'
+          elif [[ ! -e "${pkgs.ragenix}/share/zsh" ]]; then
+            echo 'Failed to install zsh completions'
+          elif [[ ! -e "${pkgs.ragenix}/share/fish" ]]; then
+            echo 'Failed to install fish completions'
+          elif [[ ! -e "${pkgs.ragenix}/share/man/man1/ragenix.1.gz" ]]; then
+            echo 'Failed to install manpage'
+          else
+            echo '${name} shell files installed successfully'
+            mkdir $out
+            exit 0
+          fi
+
+          exit 1
+        '';
+
+        checks.decrypt-with-age = pkgs.runCommand "decrypt-with-age" { } ''
+          set -euo pipefail
+
+          # Required to prevent a panic in the locale_config crate
+          # https://github.com/yaxitech/ragenix/issues/76
+          ${lib.optionalString pkgs.stdenv.isDarwin ''export LANG="en_US.UTF-8"''}
+
+          files=('${self}/example/root.passwd.age' '${self}/example/github-runner.token.age')
+
+          for file in ''${files[@]}; do
+            rage_output="$(${pkgs.rage}/bin/rage -i '${self}/example/keys/id_ed25519' -d "$file")"
+            age_output="$(${pkgs.age}/bin/age    -i '${self}/example/keys/id_ed25519' -d "$file")"
+
+            if [[ "$rage_output" != "$age_output" ]]; then
+              printf 'Decrypted plaintext for %s differs for rage and age' "$file"
+              exit 1
+            fi
+          done
+
+          echo "rage and age decryption of examples successful and equal"
+          mkdir $out
+        '';
+
+        checks.metadata = pkgs.runCommand "check-metadata" { } ''
+          set -euo pipefail
+
+          flakeDescription=${lib.escapeShellArg (import "${self}/flake.nix").description}
+          packageDescription=${lib.escapeShellArg cargoTOML.package.description}
+          if [[ "$flakeDescription" != "$packageDescription" ]]; then
+            echo 'The descriptions given in flake.nix and Cargo.toml do not match'
+            exit 1
+          fi
+
+          flakePackageName=${pkgs.ragenix.pname}
+          cargoName=${cargoTOML.package.name}
+          if [[ "$flakePackageName" != "$cargoName" ]]; then
+            echo 'The package name given in flake.nix and Cargo.toml do not match'
+            exit 1
+          fi
+
+          echo 'All metadata checks completed successfully'
+          mkdir $out # success
+        '';
+
+        # Make sure the roff and HTML manpages are up-to-date
+        checks.manpage = pkgs.runCommand "check-manpage"
+          {
+            buildInputs = with pkgs; [ ronn diffutils ];
+          } ''
+          set -euo pipefail
+
+          echo "Generate roff and HTML manpage"
+          ln -s ${self}/docs/ragenix.1.ronn .
+          ronn ragenix.1.ronn
+
+          echo "roff: strip date"
+          tail -n '+5' ${self}/docs/ragenix.1 > ragenix.1.old
+          tail -n '+5'              ragenix.1 > ragenix.1.new
+
+          diff -u ragenix.1.{old,new} > diff \
+            || (printf "roff: error, not up-to-date:\n\n%s\n" "$(cat diff)" >&2 && exit 1)
+
+          echo "html: strip date"
+          grep -v "<li class='tc'>" ${self}/docs/ragenix.1.html > ragenix.1.html.old
+          grep -v "<li class='tc'>"              ragenix.1.html > ragenix.1.html.new
+
+          diff -u ragenix.1.html.{old,new} > diff \
+            || (printf "html: error, not up-to-date:\n\n%s\n" "$(cat diff)" >&2 && exit 1)
+
+          echo 'Manpage is up-to-date'
+          mkdir -p $out
+        '';
+
+        # `nix develop`
+        devShell = pkgs.mkShell {
+          name = "${name}-dev-shell";
+
+          inputsFrom = [ self.packages."${pkgs.stdenv.system}".ragenix ];
+
+          nativeBuildInputs = with pkgs; [
+            ronn
+            rust-analyzer
+          ];
+
+          RAGENIX_NIX_BIN_PATH = "${pkgs.nix}/bin/nix";
+
+          RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+
+          shellHook = ''
+            export PATH=$PWD/target/debug:$PATH
+          '';
+        };
+      })
       )
       #
       # CHECKS SPECIFIC TO LINUX SYSTEMS
@@ -277,7 +293,7 @@
             '';
           };
 
-        checks.tests-recursive-nix = pkgs.ragenix.overrideAttrs (oldAttrs: {
+        checks.tests-recursive-nix = pkgs.ragenix.overrideAttrs (_: {
           name = "tests-recursive-nix";
           cargoCheckFeatures = [ "recursive-nix" ];
           requiredSystemFeatures = [ "recursive-nix" ];
@@ -305,7 +321,7 @@
 
         checks.age-plugin =
           let
-            rageExamplePlugin = pkgs.rage.overrideAttrs (old: rec {
+            rageExamplePlugin = pkgs.rage.overrideAttrs (_: rec {
               pname = "age-plugin-unencrypted";
               doCheck = false;
               cargoBuildFlags = [ "--example" pname ];
@@ -354,7 +370,7 @@
         inherit (agenix) nixosModules darwinModules;
 
         # Overlay to add ragenix and replace agenix
-        overlays.default = final: prev: rec {
+        overlays.default = _final: prev: rec {
           ragenix = self.packages.${prev.stdenv.hostPlatform.system}.ragenix;
           agenix = ragenix;
         };


### PR DESCRIPTION
Apart from building the main ragenix package with crane, this commit also moves `cargo clippy` and `cargo fmt` to dedicated checks. This should avoid build failures in case someone uses a different Rust version which might have different policies.