### PR TITLE
Update flake inputs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,9 @@ fn main() -> Result<(), Error> {
     println!("cargo:rustc-env=RAGENIX_NIX_BIN_PATH={nix_bin_path}");
 
     // Make the paths to the shell completion files available as environment variables
-    let Some(outdir) = env::var_os("OUT_DIR") else { return Ok(()) };
+    let Some(outdir) = env::var_os("OUT_DIR") else {
+        return Ok(());
+    };
 
     let mut app = build();
     app.set_bin_name(crate_name!());

--- a/docs/ragenix.1
+++ b/docs/ragenix.1
@@ -109,7 +109,7 @@ $ pbpaste | ragenix \-\-editor \- \-e secret\.txt\.age
 Use \fB\-\-editor\fR to generate an SSH Ed25519 private key:
 .IP "" 4
 .nf
-$ ragenix \-\-editor \'ssh\-keygen \-q \-N "" \-t ed25519 \-f\' \-e ssh_host_key\.age
+$ ragenix \-\-editor 'ssh\-keygen \-q \-N "" \-t ed25519 \-f' \-e ssh_host_key\.age
 .fi
 .IP "" 0
 .P

--- a/docs/ragenix.1.html
+++ b/docs/ragenix.1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' content='text/html;charset=utf8'>
-  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf-8'>
+  <meta name='generator' content='Ronn-NG/v0.10.1 (http://github.com/apjanke/ronn-ng/tree/0.10.1)'>
   <title>ragenix(1) - age-encrypted secrets for Nix</title>
   <style type='text/css' media='all'>
   /* style: man */

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,18 @@
     "agenix": {
       "inputs": {
         "darwin": "darwin",
+        "home-manager": "home-manager",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1682101079,
-        "narHash": "sha256-MdAhtjrLKnk2uiqun1FWABbKpLH090oeqCSiWemtuck=",
+        "lastModified": 1703433843,
+        "narHash": "sha256-nmtA4KqFboWxxoOAA6Y1okHbZh+HsXaMPFkYHsoDRDw=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "2994d002dcff5353ca1ac48ec584c7f6589fe447",
+        "rev": "417caa847f9383e111d1397039c9d4337d024bf0",
         "type": "github"
       },
       "original": {
@@ -23,23 +25,16 @@
     },
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": [
-          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1681680516,
-        "narHash": "sha256-EB8Adaeg4zgcYDJn9sR6UMjN/OHdIiMMK19+3LmmXQY=",
+        "lastModified": 1707685877,
+        "narHash": "sha256-XoXRS+5whotelr1rHiZle5t5hDg9kpguS5yk8c8qzOc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "54b63c8eae4c50172cb50b612946ff1d2bc1c75c",
+        "rev": "2c653e4478476a52c6aa3ac0495e4dea7449ea0e",
         "type": "github"
       },
       "original": {
@@ -56,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "lastModified": 1700795494,
+        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
         "type": "github"
       },
       "original": {
@@ -70,47 +65,52 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
-    "flake-utils": {
+    "home-manager": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "lastModified": 1703113217,
+        "narHash": "sha256-7ulcXOk63TIT2lVDSExj7XzFx09LpdSAPtvgtM7yQPE=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "3bfaacf46133c037bb356193bd2f1765d9dc82c1",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "nix-community",
+        "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681920287,
-        "narHash": "sha256-+/d6XQQfhhXVfqfLROJoqj3TuG38CAeoT6jO1g9r1k0=",
+        "lastModified": 1707546158,
+        "narHash": "sha256-nYYJTpzfPMDxI8mzhQsYjIUX+grorqjKEU9Np6Xwy/0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "645bc49f34fa8eff95479f0345ff57e55b53437e",
+        "rev": "d934204a0f8d9198e1e4515dd6fec76a139c87f0",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682129965,
-        "narHash": "sha256-1KRPIorEL6pLpJR04FwAqqnt4Tzcm4MqD84yhlD+XSk=",
+        "lastModified": 1707617562,
+        "narHash": "sha256-Kk2vv5e4MqKPjelKoYsa6YaUyv3pvjWY9nJSnP2QU9w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2c417c0460b788328220120c698630947547ee83",
+        "rev": "a22bbbee9b479c6d95b4819135e856a6d447b3ba",
         "type": "github"
       },
       "original": {
@@ -153,6 +153,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,8 @@
                 set -euo pipefail
                 find target/**/release/examples -name ${pname} \
                   -exec install -D {} $out/bin/${pname} \;
+                # strip.sh uses unset variables
+                set +u
               '';
             });
             plugins = [ rageExamplePlugin ];

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,6 @@
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.rust-overlay.follows = "rust-overlay";
     };
     agenix = {
       url = "github:ryantm/agenix";

--- a/src/ragenix/mod.rs
+++ b/src/ragenix/mod.rs
@@ -125,7 +125,7 @@ pub(crate) fn parse_rules<P: AsRef<Path>>(rules_path: P) -> Result<Vec<RagenixRu
 
     // It's fine to force unwrap here as we validated the JSON schema
     let mut rules: Vec<RagenixRule> = Vec::new();
-    for (rel_path, val) in instance.as_object().unwrap().iter() {
+    for (rel_path, val) in instance.as_object().unwrap() {
         let dir = fs::canonicalize(rules_path.as_ref().parent().unwrap())?;
         let p = dir.join(rel_path);
         let public_keys = val.as_object().unwrap()["publicKeys"]

--- a/src/util.rs
+++ b/src/util.rs
@@ -146,7 +146,7 @@ mod test_split_editor {
 
     #[test]
     fn parse_editor_complex_2() -> Result<()> {
-        let actual = split_editor(r#"sed -i 's/.*/ x  /'"#)?;
+        let actual = split_editor(r"sed -i 's/.*/ x  /'")?;
         let expected = (
             String::from("sed"),
             Some(vec![String::from("-i"), String::from("s/.*/ x  /")]),
@@ -157,7 +157,7 @@ mod test_split_editor {
 
     #[test]
     fn parse_editor_stdin() -> Result<()> {
-        let actual = split_editor(r#" - "#)?;
+        let actual = split_editor(r" - ")?;
         let expected = (String::from("-"), None);
         assert_eq!(actual, expected);
         Ok(())


### PR DESCRIPTION
Updated Flake dependencies through `nix flake update`.

```
Resolved URL:  git+file:///home/runner/work/ragenix/ragenix?shallow=1
Locked URL:    git+file:///home/runner/work/ragenix/ragenix?ref=refs/heads/main&rev=f9249cd3a3227aa5b2f78354d46b999d9822dc59&shallow=1
Description:   A rust drop-in replacement for agenix
Path:          /nix/store/nmsjswjd8sg09ifaknzl6awcmhxh7s3n-source
Revision:      f9249cd3a3227aa5b2f78354d46b999d9822dc59
Last modified: 2023-11-12 02:12:59
Inputs:
├───agenix: github:ryantm/agenix/daf42cb35b2dc614d1551e37f96406e4c4a2d3e4
│   ├───darwin: github:lnl7/nix-darwin/87b9d090ad39b25b2400029c64825fc2a8868943
│   │   └───nixpkgs follows input 'agenix/nixpkgs'
│   ├───home-manager: github:nix-community/home-manager/32d3e39c491e2f91152c84f8ad8b003420eab0a1
│   │   └───nixpkgs follows input 'agenix/nixpkgs'
│   └───nixpkgs follows input 'nixpkgs'
├───crane: github:ipetkov/crane/6849911446e18e520970cc6b7a691e64ee90d649
│   └───nixpkgs follows input 'nixpkgs'
├───flake-utils: github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384
│   └───systems: github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e
├───nixpkgs: github:nixos/nixpkgs/85f1ba3e51676fa8cc604a3d863d729026a6b8eb
└───rust-overlay: github:oxalica/rust-overlay/efd15e11c8954051a47679e7718b4c2a9b68ce27
    ├───flake-utils follows input 'flake-utils'
    └───nixpkgs follows input 'nixpkgs'

```

Updated Cargo dependencies through `cargo update`.

Dependency status of `main` prior to this PR:
[![dependency status](https://deps.rs/repo/github/yaxitech/ragenix/status.svg)
](https://deps.rs/repo/github/yaxitech/ragenix)