### PR TITLE
Allow specific files to be re-encrypted with `--rekey`

### DIFF
--- a/docs/ragenix.1
+++ b/docs/ragenix.1
@@ -1,6 +1,6 @@
-.\" generated with Ronn-NG/v0.9.1
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "RAGENIX" "1" "January 2022" ""
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "RAGENIX" "1" "January 1980" ""
 .SH "NAME"
 \fBragenix\fR \- age\-encrypted secrets for Nix
 .SH "SYNOPSIS"
@@ -32,6 +32,13 @@ Giving the special token \fB\-\fR as a \fIPROGRAM\fR causes \fBragenix\fR to rea
 .TP
 \fB\-r\fR, \fB\-\-rekey\fR
 Decrypt all secrets given in the rules configuration file and encrypt them with the defined public keys\. If a secret file does not exist yet, it is ignored\. This option is useful to grant a new recipient access to one or multiple secrets\.
+.IP
+If the \fB\-\-identity\fR option is not given, \fBragenix\fR tries to decrypt \fIPATH\fR with the default SSH private keys\. See \fB\-\-identity\fR for details\.
+.IP
+When rekeying, \fBragenix\fR does not write any plaintext data to disk; all processing happens in\-memory\.
+.TP
+\fB\-R\fR, \fB\-\-rekey\-one\fR \fIPATH\fR
+Decrypt specified secrets given in the rules configuration file and encrypt them with the defined public keys\. This option is useful to grant a new recipient access to specific secrets\.
 .IP
 If the \fB\-\-identity\fR option is not given, \fBragenix\fR tries to decrypt \fIPATH\fR with the default SSH private keys\. See \fB\-\-identity\fR for details\.
 .IP

--- a/docs/ragenix.1.html
+++ b/docs/ragenix.1.html
@@ -140,6 +140,19 @@ store.</p>
     <p>When rekeying, <code>ragenix</code> does not write any plaintext data to disk; all
   processing happens in-memory.</p>
 </dd>
+<dt>
+<code>-R</code>, <code>--rekey-one</code> <var>PATH</var>
+</dt>
+<dd>  Decrypt specified secrets given in the rules configuration file and encrypt
+  them with the defined public keys. This option is useful to grant a new
+  recipient access to specific secrets.
+
+    <p>If the <code>--identity</code> option is not given, <code>ragenix</code> tries to decrypt <var>PATH</var>
+  with the default SSH private keys. See <code>--identity</code> for details.</p>
+
+    <p>When rekeying, <code>ragenix</code> does not write any plaintext data to disk; all
+  processing happens in-memory.</p>
+</dd>
 </dl>
 
 <h2 id="COMMON-OPTIONS">COMMON OPTIONS</h2>
@@ -268,7 +281,7 @@ ragenix.override { plugins = [ age-plugin-yubikey ]; }
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>January 2022</li>
+    <li class='tc'>January 1980</li>
     <li class='tr'>ragenix(1)</li>
   </ol>
 

--- a/docs/ragenix.1.ronn
+++ b/docs/ragenix.1.ronn
@@ -57,6 +57,17 @@ store.
     When rekeying, `ragenix` does not write any plaintext data to disk; all
     processing happens in-memory.
 
+* `-R`, `--rekey-one` <PATH>:
+    Decrypt specified secrets given in the rules configuration file and encrypt
+    them with the defined public keys. This option is useful to grant a new
+    recipient access to specific secrets.
+
+    If the `--identity` option is not given, `ragenix` tries to decrypt <PATH>
+    with the default SSH private keys. See `--identity` for details.
+
+    When rekeying, `ragenix` does not write any plaintext data to disk; all
+    processing happens in-memory.
+
 ## COMMON OPTIONS
 
 * `--rules` <PATH>:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ pub(crate) struct Opts {
     pub editor: Option<String>,
     pub identities: Option<Vec<String>>,
     pub rekey: bool,
+    pub rekey_chosen: Option<Vec<String>>,
     pub rules: String,
     pub schema: bool,
     pub verbose: bool,
@@ -41,6 +42,15 @@ fn build() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("rekey-one")
+                .help("re-encrypts specified secrets with specified recipients")
+                .long("rekey-one")
+                .short('R')
+                .value_name("FILE")
+                .action(ArgAction::Append)
+                .value_hint(ValueHint::FilePath),
+        )
+        .arg(
             Arg::new("identity")
                 .help("private key to use when decrypting")
                 .long("identity")
@@ -66,7 +76,7 @@ fn build() -> Command {
         )
         .group(
             ArgGroup::new("action")
-                .args(["edit", "rekey", "schema"])
+                .args(["edit", "rekey", "rekey-one", "schema"])
                 .required(true),
         )
         .arg(
@@ -108,6 +118,9 @@ where
             .get_many::<String>("identity")
             .map(|vals| vals.cloned().collect::<Vec<_>>()),
         rekey: matches.get_flag("rekey"),
+        rekey_chosen: matches
+            .get_many::<String>("rekey-one")
+            .map(|vals| vals.cloned().collect::<Vec<_>>()),
         rules: matches
             .get_one::<String>("rules")
             .cloned()

--- a/src/ragenix/mod.rs
+++ b/src/ragenix/mod.rs
@@ -146,6 +146,7 @@ pub(crate) fn parse_rules<P: AsRef<Path>>(rules_path: P) -> Result<Vec<RagenixRu
 pub(crate) fn rekey(
     entries: &[RagenixRule],
     identities: &[String],
+    no_exist_ok: bool,
     mut writer: impl Write,
 ) -> Result<()> {
     let identities = age::get_identities(identities)?;
@@ -153,8 +154,10 @@ pub(crate) fn rekey(
         if entry.path.exists() {
             writeln!(writer, "Rekeying {}", entry.path.display())?;
             age::rekey(&entry.path, &identities, &entry.public_keys)?;
-        } else {
+        } else if no_exist_ok {
             writeln!(writer, "Does not exist, ignored: {}", entry.path.display())?;
+        } else {
+            return Err(eyre!("Does not exist: {}", entry.path.display()));
         }
     }
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 //! Util functions
 
 use std::{
-    fs::File,
+    fs::{self, File},
     io,
     path::{Component, Path, PathBuf},
 };
@@ -47,6 +47,14 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     ret
+}
+
+/// Make a path relative to the current working directory (rules format)
+pub(crate) fn canonicalize_rule_path<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
+    let path_normalized = normalize_path(path.as_ref());
+    Ok(std::env::current_dir()
+        .and_then(fs::canonicalize)
+        .map(|p| p.join(path_normalized))?)
 }
 
 /// Hash a file using SHA-256


### PR DESCRIPTION
Sometimes it's useful to rekey only specific secrets. This change allows
paths to be passed to the `--rekey` option in order to only re-encrypt
them, defaulting to all as before.

An example of where this is useful is when adding a new machine to a [centralised repo with many secrets](https://git.nul.ie/dev/nixfiles/src/branch/master/secrets), where only a few that are shared between all configs need to be rekeyed.