### PR TITLE
Add `aarch64-unknown-linux-musl` target

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -7,5 +7,6 @@ targets = [
     "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
     "x86_64-unknown-linux-musl",
 ]


### PR DESCRIPTION
On my Raspberry Pi 4 running NixOS, the following error occurred which appears to be caused by #150.

```
error: builder for '/nix/store/f5bx79d0kfag2pvlkvi8k49y4acabjnq-ragenix-0.1.0.drv' failed with exit code 101;
       last 10 log lines:
       >   |
       >   = note: the `aarch64-unknown-linux-musl` target may not be installed
       >   = help: consider downloading the target with `rustup target add aarch64-unknown-linux-musl`
       >
       > For more information about this error, try `rustc --explain E0463`.
       > error: could not compile `cfg-if` (lib) due to 1 previous error
       > warning: build failed, waiting for other jobs to finish...
       > error: could not compile `libc` (lib) due to 1 previous error
       > error: could not compile `zeroize` (lib) due to 1 previous error
       > error: could not compile `typenum` (lib) due to 1 previous error
       For full logs, run 'nix log /nix/store/f5bx79d0kfag2pvlkvi8k49y4acabjnq-ragenix-0.1.0.drv'.
```

It was fixed by simply adding `aarch64-unknown-linux-musl` as a target.
I am not familiar with Rust, so sorry if this PR is off the mark.
