### PR TITLE
Update flake inputs to fix build on newer nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754433428,
-        "narHash": "sha256-NA/FT2hVhKDftbHSwVnoRTFhes62+7dxZbxj5Gxvghs=",
+        "lastModified": 1761656077,
+        "narHash": "sha256-lsNWuj4Z+pE7s0bd2OKicOFq9bK86JE0ZGeKJbNqb94=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "9edb1787864c4f59ae5074ad498b6272b3ec308d",
+        "rev": "9ba0d85de3eaa7afeab493fed622008b6e4924f5",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1755993354,
-        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
+        "lastModified": 1760924934,
+        "narHash": "sha256-tuuqY5aU7cUkR71sO2TraVKK2boYrdW3gCSXUkF4i44=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
+        "rev": "c6b4d5308293d0d04fcfeee92705017537cad02f",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756521112,
-        "narHash": "sha256-/YW9DI+vZ2lbTvYAek6BsudUXdpWr0FybTDod4P42L4=",
+        "lastModified": 1761791894,
+        "narHash": "sha256-myRIDh+PxaREz+z9LzbqBJF+SnTFJwkthKDX9zMyddY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2243e3f251ea18486f83133cf8e325d2b9b71e89",
+        "rev": "59c45eb69d9222a4362673141e00ff77842cd219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Namely needed for https://github.com/oxalica/rust-overlay/commit/37f8f092415b444c3bed6eda6bcbee51cee22e5d.

Flake lock file updates:

• Updated input 'agenix':
    'github:ryantm/agenix/9edb1787864c4f59ae5074ad498b6272b3ec308d?narHash=sha256-NA/FT2hVhKDftbHSwVnoRTFhes62%2B7dxZbxj5Gxvghs%3D' (2025-08-05)
  → 'github:ryantm/agenix/9ba0d85de3eaa7afeab493fed622008b6e4924f5?narHash=sha256-lsNWuj4Z%2BpE7s0bd2OKicOFq9bK86JE0ZGeKJbNqb94%3D' (2025-10-28)
• Updated input 'crane':
    'github:ipetkov/crane/25bd41b24426c7734278c2ff02e53258851db914?narHash=sha256-FCRRAzSaL/%2BumLIm3RU3O/%2BfJ2ssaPHseI2SSFL8yZU%3D' (2025-08-23)
  → 'github:ipetkov/crane/c6b4d5308293d0d04fcfeee92705017537cad02f?narHash=sha256-tuuqY5aU7cUkR71sO2TraVKK2boYrdW3gCSXUkF4i44%3D' (2025-10-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d7600c775f877cd87b4f5a831c28aa94137377aa?narHash=sha256-tlOn88coG5fzdyqz6R93SQL5Gpq%2Bm/DsWpekNFhqPQk%3D' (2025-08-30)
  → 'github:nixos/nixpkgs/08dacfca559e1d7da38f3cf05f1f45ee9bfd213c?narHash=sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI%3D' (2025-10-28)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/2243e3f251ea18486f83133cf8e325d2b9b71e89?narHash=sha256-/YW9DI%2BvZ2lbTvYAek6BsudUXdpWr0FybTDod4P42L4%3D' (2025-08-30)
  → 'github:oxalica/rust-overlay/59c45eb69d9222a4362673141e00ff77842cd219?narHash=sha256-myRIDh%2BPxaREz%2Bz9LzbqBJF%2BSnTFJwkthKDX9zMyddY%3D' (2025-10-30)