### PR TITLE
cli: add `-d`/`--decrypt` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ For the full documentation, read the [ragenix(1) man page](https://htmlpreview.g
 
 ```
 USAGE:
-    ragenix [OPTIONS] <--edit <FILE>|--rekey|--schema>
+    ragenix [OPTIONS] <--decrypt <FILE>|--edit <FILE>|--rekey|--schema>
 
 OPTIONS:
+    -d, --decrypt <FILE>               decrypts the age-encrypted FILE to stdout
     -e, --edit <FILE>                  edits the age-encrypted FILE using $EDITOR
         --editor <EDITOR>              editor to use when editing FILE [env: EDITOR=vim]
     -h, --help                         Print help information

--- a/docs/ragenix.1
+++ b/docs/ragenix.1
@@ -1,10 +1,12 @@
-.\" generated with Ronn-NG/v0.9.1
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "RAGENIX" "1" "January 2022" ""
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "RAGENIX" "1" "February 2026" ""
 .SH "NAME"
 \fBragenix\fR \- age\-encrypted secrets for Nix
 .SH "SYNOPSIS"
-\fBragenix\fR [\fB\-\-rules\fR \fIPATH\fR=\./secrets\.nix] [\fB\-i\fR \fIPATH\fR]\|\.\|\.\|\. (\fB\-e\fR \fIPATH\fR | \fB\-r\fR)
+\fBragenix\fR [\fB\-\-rules\fR \fIPATH\fR=\./secrets\.nix] [\fB\-i\fR \fIPATH\fR]\|\.\|\.\|\. (\fB\-d\fR \fIPATH\fR | \fB\-e\fR \fIPATH\fR | \fB\-r\fR)
+.br
+\fBragenix\fR \fB\-d\fR \fIPATH\fR
 .br
 \fBragenix\fR \fB\-e\fR \fIPATH\fR
 .br
@@ -13,6 +15,13 @@
 .SH "DESCRIPTION"
 \fBragenix\fR encrypts secrets defined in a Nix configuration expression using \fBage(1)\fR\. It is safe to publicly expose the resulting age\-encrypted files, e\.g\., by checking them into version control or copying them to the world\-readable Nix store\.
 .SH "OPTIONS"
+.TP
+\fB\-d\fR, \fB\-\-decrypt\fR \fIPATH\fR
+Decrypt the age\-encrypted file at \fIPATH\fR and output the plaintext to standard output\. This is useful for directly accessing the contents of a secret file without opening an editor\.
+.IP
+If the \fB\-\-identity\fR option is not given, \fBragenix\fR tries to decrypt \fIPATH\fR with the default SSH private keys\. See \fB\-\-identity\fR for details\.
+.IP
+Unlike the \fB\-\-edit\fR option, this does not require the file to match a rule in the rules configuration file\.
 .TP
 \fB\-e\fR, \fB\-\-edit\fR \fIPATH\fR
 Decrypt the file at \fIPATH\fR and open it for editing\. If the \fIPATH\fR does not exist yet, \fBragenix\fR opens an empty file for editing\. In any case, the given \fIPATH\fR has to match a rule as configured in the file given to the \fB\-\-rules\fR option\. After editing, \fBragenix\fR encrypts the updated contents and replaces the original file\.
@@ -89,6 +98,14 @@ id_ed25519  id_ed25519\.pub
 $ ls /var/lib/secrets/
 rules\.nix secret\.txt\.age
 $ ragenix \-\-rules /var/lib/secrets/rules\.nix \-e secret\.txt\.age
+.fi
+.IP "" 0
+.P
+Decrypt a secret file to stdout:
+.IP "" 4
+.nf
+$ ragenix \-\-decrypt secret\.txt\.age
+This is the secret content
 .fi
 .IP "" 0
 .P

--- a/docs/ragenix.1.html
+++ b/docs/ragenix.1.html
@@ -79,7 +79,8 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>ragenix</code> [<code>--rules</code> <var>PATH</var>=./secrets.nix] [<code>-i</code> <var>PATH</var>]... (<code>-e</code> <var>PATH</var> | <code>-r</code>)<br>
+<p><code>ragenix</code> [<code>--rules</code> <var>PATH</var>=./secrets.nix] [<code>-i</code> <var>PATH</var>]... (<code>-d</code> <var>PATH</var> | <code>-e</code> <var>PATH</var> | <code>-r</code>)<br>
+<code>ragenix</code> <code>-d</code> <var>PATH</var><br>
 <code>ragenix</code> <code>-e</code> <var>PATH</var><br>
 <code>ragenix</code> <code>-r</code><br></p>
 
@@ -93,6 +94,19 @@ store.</p>
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <dl>
+<dt>
+<code>-d</code>, <code>--decrypt</code> <var>PATH</var>
+</dt>
+<dd>  Decrypt the age-encrypted file at <var>PATH</var> and output the plaintext to
+  standard output. This is useful for directly accessing the contents of a
+  secret file without opening an editor.
+
+    <p>If the <code>--identity</code> option is not given, <code>ragenix</code> tries to decrypt <var>PATH</var>
+  with the default SSH private keys. See <code>--identity</code> for details.</p>
+
+    <p>Unlike the <code>--edit</code> option, this does not require the file to match a rule
+  in the rules configuration file.</p>
+</dd>
 <dt>
 <code>-e</code>, <code>--edit</code> <var>PATH</var>
 </dt>
@@ -235,6 +249,12 @@ rules.nix secret.txt.age
 $ ragenix --rules /var/lib/secrets/rules.nix -e secret.txt.age
 </code></pre>
 
+<p>Decrypt a secret file to stdout:</p>
+
+<pre><code>$ ragenix --decrypt secret.txt.age
+This is the secret content
+</code></pre>
+
 <p>Rekey all secrets given in ./secrets.nix with the age identity
 ~/.age/ragenix.key:</p>
 
@@ -268,7 +288,7 @@ ragenix.override { plugins = [ age-plugin-yubikey ]; }
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>January 2022</li>
+    <li class='tc'>February 2026</li>
     <li class='tr'>ragenix(1)</li>
   </ol>
 

--- a/docs/ragenix.1.ronn
+++ b/docs/ragenix.1.ronn
@@ -3,7 +3,8 @@ ragenix(1) -- age-encrypted secrets for Nix
 
 ## SYNOPSIS
 
-`ragenix` [`--rules` <PATH>=./secrets.nix] [`-i` <PATH>]... (`-e` <PATH> | `-r`)<br>
+`ragenix` [`--rules` <PATH>=./secrets.nix] [`-i` <PATH>]... (`-d` <PATH> | `-e` <PATH> | `-r`)<br>
+`ragenix` `-d` <PATH><br>
 `ragenix` `-e` <PATH><br>
 `ragenix` `-r`<br>
 
@@ -15,6 +16,17 @@ by checking them into version control or copying them to the world-readable Nix
 store.
 
 ## OPTIONS
+
+* `-d`, `--decrypt` <PATH>:
+    Decrypt the age-encrypted file at <PATH> and output the plaintext to
+    standard output. This is useful for directly accessing the contents of a
+    secret file without opening an editor.
+
+    If the `--identity` option is not given, `ragenix` tries to decrypt <PATH>
+    with the default SSH private keys. See `--identity` for details.
+
+    Unlike the `--edit` option, this does not require the file to match a rule
+    in the rules configuration file.
 
 * `-e`, `--edit` <PATH>:
     Decrypt the file at <PATH> and open it for editing. If the <PATH> does not
@@ -134,6 +146,11 @@ file different from ./secrets.nix:
     $ ls /var/lib/secrets/
     rules.nix secret.txt.age
     $ ragenix --rules /var/lib/secrets/rules.nix -e secret.txt.age
+
+Decrypt a secret file to stdout:
+
+    $ ragenix --decrypt secret.txt.age
+    This is the secret content
 
 Rekey all secrets given in ./secrets.nix with the age identity
 ~/.age/ragenix.key:

--- a/src/age.rs
+++ b/src/age.rs
@@ -153,6 +153,22 @@ pub(crate) fn decrypt<P: AsRef<Path>>(
         })
 }
 
+/// Decrypt an age-encrypted file and write the plaintext to a writer.
+pub(crate) fn decrypt_to_writer<P: AsRef<Path>>(
+    input_file: P,
+    identities: &[Box<dyn age::Identity>],
+    mut writer: impl io::Write,
+) -> Result<()> {
+    let decryptor = get_age_decryptor(input_file)?;
+    decryptor
+        .decrypt(identities.iter().map(|i| i.as_ref() as &dyn age::Identity))
+        .map_err(Into::into)
+        .and_then(|mut plaintext_reader| {
+            io::copy(&mut plaintext_reader, &mut writer)?;
+            Ok(())
+        })
+}
+
 /// Encrypt a plaintext file to an age-encrypted file.
 ///
 /// The output file is created with a mode of `0o644`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use clap::{
 #[allow(dead_code)] // False positive
 #[derive(Debug, Clone)]
 pub(crate) struct Opts {
+    pub decrypt: Option<String>,
     pub edit: Option<String>,
     pub editor: Option<String>,
     pub identities: Option<Vec<String>>,
@@ -23,6 +24,15 @@ fn build() -> Command {
         .version(crate_version!())
         .author(crate_authors!())
         .about(crate_description!())
+        .arg(
+            Arg::new("decrypt")
+                .help("decrypts the age-encrypted FILE to stdout")
+                .long("decrypt")
+                .short('d')
+                .num_args(1)
+                .value_name("FILE")
+                .value_hint(ValueHint::FilePath),
+        )
         .arg(
             Arg::new("edit")
                 .help("edits the age-encrypted FILE using $EDITOR")
@@ -66,7 +76,7 @@ fn build() -> Command {
         )
         .group(
             ArgGroup::new("action")
-                .args(["edit", "rekey", "schema"])
+                .args(["decrypt", "edit", "rekey", "schema"])
                 .required(true),
         )
         .arg(
@@ -102,6 +112,7 @@ where
     let matches = app.get_matches_from(itr);
 
     Opts {
+        decrypt: matches.get_one::<String>("decrypt").cloned(),
         edit: matches.get_one::<String>("edit").cloned(),
         editor: matches.get_one::<String>("editor").cloned(),
         identities: matches

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,17 @@ fn main() -> Result<()> {
     color_eyre::install()?;
     let opts = cli::parse_args(env::args());
 
-    if opts.schema {
+    if let Some(path) = &opts.decrypt {
+        let identities = opts.identities.unwrap_or_default();
+        let path = Path::new(path);
+
+        if !path.exists() {
+            eprintln!("error: file does not exist: '{}'", path.display());
+            process::exit(1);
+        }
+
+        ragenix::decrypt_to_writer(path, &identities, &mut std::io::stdout())?;
+    } else if opts.schema {
         print!("{}", ragenix::AGENIX_JSON_SCHEMA_STRING);
     } else {
         if let Err(report) = ragenix::validate_rules_file(&opts.rules) {

--- a/src/ragenix/mod.rs
+++ b/src/ragenix/mod.rs
@@ -160,6 +160,18 @@ pub(crate) fn rekey(
     Ok(())
 }
 
+/// Decrypt an age-encrypted file and write the plaintext to a writer.
+///
+/// This does not require a rules file — it decrypts the given path directly.
+pub(crate) fn decrypt_to_writer(
+    path: &Path,
+    identity_paths: &[String],
+    writer: impl Write,
+) -> Result<()> {
+    let identities = age::get_identities(identity_paths)?;
+    age::decrypt_to_writer(path, &identities, writer)
+}
+
 /// Edit/create an age-encrypted file
 ///
 /// If the file doesn't exist yet, a new file is created and opened in `editor`.

--- a/tests/ragenix.rs
+++ b/tests/ragenix.rs
@@ -432,3 +432,42 @@ fn fails_for_invalid_recipient() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
+fn decrypt_works() -> Result<()> {
+    let (_dir, path) = copy_example_to_tmpdir()?;
+
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    let assert = cmd
+        .current_dir(&path)
+        .arg("--decrypt")
+        .arg("github-runner.token.age")
+        .arg("--identity")
+        .arg("keys/id_ed25519")
+        .assert();
+
+    assert
+        .success()
+        .stdout(predicate::str::contains("wurzelpfropf!"));
+
+    Ok(())
+}
+
+#[test]
+fn decrypt_missing_file_errors() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    let assert = cmd
+        .current_dir(dir.path())
+        .arg("--decrypt")
+        .arg("nonexistent.age")
+        .assert();
+
+    assert
+        .failure()
+        .stderr(predicate::str::contains("does not exist"));
+
+    Ok(())
+}


### PR DESCRIPTION
- Supersedes #161

agenix supports decrypting secrets to stdout but ragenix had no equivalent. Unlike `--edit`, `--decrypt` skips rules validation, needing only a path and an identity. Decryption streams through the age decryptor to stdout with no intermediate temp file.

This PR builds upon #161, as it's been stale for a few months. I addressed the review comments and reworked the implementation to stream directly through the age decryptor instead of round-tripping through a temp file.