### PR TITLE
Add --lazy flag to skip rekeying unchanged secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ version = "0.1.0"
 dependencies = [
  "age",
  "assert_cmd",
+ "base64 0.22.1",
  "clap",
  "clap_complete",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
  "age",
  "assert_cmd",
  "base64 0.22.1",
+ "bech32",
  "clap",
  "clap_complete",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ recursive-nix = []
 
 [dependencies]
 age = { version = "^0.10", default-features = false, features = [ "cli-common", "ssh", "armor", "plugin" ] }
+base64 = "^0.22"
 clap = { version = "^4.0", features = [ "cargo", "env" ] }
 color-eyre = { version = "^0.6", default-features = false, features = [ "track-caller" ] }
 home = "^0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ recursive-nix = []
 [dependencies]
 age = { version = "^0.10", default-features = false, features = [ "cli-common", "ssh", "armor", "plugin" ] }
 base64 = "^0.22"
+bech32 = "^0.9"
 clap = { version = "^4.0", features = [ "cargo", "env" ] }
 color-eyre = { version = "^0.6", default-features = false, features = [ "track-caller" ] }
 home = "^0.5"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ OPTIONS:
         --editor <EDITOR>              editor to use when editing FILE [env: EDITOR=vim]
     -h, --help                         Print help information
     -i, --identity <PRIVATE_KEY>...    private key to use when decrypting
+    -l, --lazy                         when rekeying, skip secrets which are already encrypted
+                                       to the recipients
     -r, --rekey                        re-encrypts all secrets with specified recipients
         --rules <RULES>                path to Nix file specifying recipient public keys [env:
                                        RULES=] [default: ./secrets.nix]

--- a/docs/ragenix.1
+++ b/docs/ragenix.1
@@ -40,7 +40,7 @@ When rekeying, \fBragenix\fR does not write any plaintext data to disk; all proc
 \fB\-l\fR, \fB\-\-lazy\fR
 Only valid in combination with \fB\-\-rekey\fR\. Skip secrets which are already encrypted to the recipients given in the rules configuration file, leaving the files untouched\.
 .IP
-\fBragenix\fR decides based on the age header of a secret file: SSH recipients are compared by their fingerprint tags while X25519 recipients are only compared by their number as age files do not identify X25519 recipients by design\. Consequently, replacing an X25519 recipient with another one does not cause a rekey of a secret\. The same holds for removing a plugin recipient\. After such changes, rekey without the \fB\-\-lazy\fR option\.
+\fBragenix\fR decides based on the age header of a secret file: SSH and YubiKey (age\-plugin\-yubikey) recipients are compared by their fingerprint tags while X25519 recipients are only compared by their number as age files do not identify X25519 recipients by design\. Consequently, replacing an X25519 recipient with another one or removing a recipient of any other age plugin does not cause a rekey of a secret\. After such changes, rekey without the \fB\-\-lazy\fR option\. Secrets whose rules contain recipients of age plugins other than age\-plugin\-yubikey are always rekeyed\.
 .SH "COMMON OPTIONS"
 .TP
 \fB\-\-rules\fR \fIPATH\fR

--- a/docs/ragenix.1
+++ b/docs/ragenix.1
@@ -1,14 +1,14 @@
-.\" generated with Ronn-NG/v0.9.1
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "RAGENIX" "1" "January 2022" ""
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "RAGENIX" "1" "January 1980" ""
 .SH "NAME"
 \fBragenix\fR \- age\-encrypted secrets for Nix
 .SH "SYNOPSIS"
-\fBragenix\fR [\fB\-\-rules\fR \fIPATH\fR=\./secrets\.nix] [\fB\-i\fR \fIPATH\fR]\|\.\|\.\|\. (\fB\-e\fR \fIPATH\fR | \fB\-r\fR)
+\fBragenix\fR [\fB\-\-rules\fR \fIPATH\fR=\./secrets\.nix] [\fB\-i\fR \fIPATH\fR]\|\.\|\.\|\. (\fB\-e\fR \fIPATH\fR | \fB\-r\fR [\fB\-l\fR])
 .br
 \fBragenix\fR \fB\-e\fR \fIPATH\fR
 .br
-\fBragenix\fR \fB\-r\fR
+\fBragenix\fR \fB\-r\fR [\fB\-l\fR]
 .br
 .SH "DESCRIPTION"
 \fBragenix\fR encrypts secrets defined in a Nix configuration expression using \fBage(1)\fR\. It is safe to publicly expose the resulting age\-encrypted files, e\.g\., by checking them into version control or copying them to the world\-readable Nix store\.
@@ -36,6 +36,11 @@ Decrypt all secrets given in the rules configuration file and encrypt them with 
 If the \fB\-\-identity\fR option is not given, \fBragenix\fR tries to decrypt \fIPATH\fR with the default SSH private keys\. See \fB\-\-identity\fR for details\.
 .IP
 When rekeying, \fBragenix\fR does not write any plaintext data to disk; all processing happens in\-memory\.
+.TP
+\fB\-l\fR, \fB\-\-lazy\fR
+Only valid in combination with \fB\-\-rekey\fR\. Skip secrets which are already encrypted to the recipients given in the rules configuration file, leaving the files untouched\.
+.IP
+\fBragenix\fR decides based on the age header of a secret file: SSH recipients are compared by their fingerprint tags while X25519 recipients are only compared by their number as age files do not identify X25519 recipients by design\. Consequently, replacing an X25519 recipient with another one does not cause a rekey of a secret\. The same holds for removing a plugin recipient\. After such changes, rekey without the \fB\-\-lazy\fR option\.
 .SH "COMMON OPTIONS"
 .TP
 \fB\-\-rules\fR \fIPATH\fR

--- a/docs/ragenix.1.html
+++ b/docs/ragenix.1.html
@@ -79,9 +79,9 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>ragenix</code> [<code>--rules</code> <var>PATH</var>=./secrets.nix] [<code>-i</code> <var>PATH</var>]... (<code>-e</code> <var>PATH</var> | <code>-r</code>)<br>
+<p><code>ragenix</code> [<code>--rules</code> <var>PATH</var>=./secrets.nix] [<code>-i</code> <var>PATH</var>]... (<code>-e</code> <var>PATH</var> | <code>-r</code> [<code>-l</code>])<br>
 <code>ragenix</code> <code>-e</code> <var>PATH</var><br>
-<code>ragenix</code> <code>-r</code><br></p>
+<code>ragenix</code> <code>-r</code> [<code>-l</code>]<br></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -139,6 +139,21 @@ store.</p>
 
     <p>When rekeying, <code>ragenix</code> does not write any plaintext data to disk; all
   processing happens in-memory.</p>
+</dd>
+<dt>
+<code>-l</code>, <code>--lazy</code>
+</dt>
+<dd>  Only valid in combination with <code>--rekey</code>. Skip secrets which are already
+  encrypted to the recipients given in the rules configuration file,
+  leaving the files untouched.
+
+    <p><code>ragenix</code> decides based on the age header of a secret file: SSH
+  recipients are compared by their fingerprint tags while X25519
+  recipients are only compared by their number as age files do not
+  identify X25519 recipients by design. Consequently, replacing an X25519
+  recipient with another one does not cause a rekey of a secret. The same
+  holds for removing a plugin recipient. After such changes, rekey without
+  the <code>--lazy</code> option.</p>
 </dd>
 </dl>
 
@@ -268,7 +283,7 @@ ragenix.override { plugins = [ age-plugin-yubikey ]; }
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>January 2022</li>
+    <li class='tc'>January 1980</li>
     <li class='tr'>ragenix(1)</li>
   </ol>
 

--- a/docs/ragenix.1.html
+++ b/docs/ragenix.1.html
@@ -147,13 +147,15 @@ store.</p>
   encrypted to the recipients given in the rules configuration file,
   leaving the files untouched.
 
-    <p><code>ragenix</code> decides based on the age header of a secret file: SSH
-  recipients are compared by their fingerprint tags while X25519
-  recipients are only compared by their number as age files do not
-  identify X25519 recipients by design. Consequently, replacing an X25519
-  recipient with another one does not cause a rekey of a secret. The same
-  holds for removing a plugin recipient. After such changes, rekey without
-  the <code>--lazy</code> option.</p>
+    <p><code>ragenix</code> decides based on the age header of a secret file: SSH and
+  YubiKey (age-plugin-yubikey) recipients are compared by their
+  fingerprint tags while X25519 recipients are only compared by their
+  number as age files do not identify X25519 recipients by design.
+  Consequently, replacing an X25519 recipient with another one or removing
+  a recipient of any other age plugin does not cause a rekey of a secret.
+  After such changes, rekey without the <code>--lazy</code> option. Secrets whose
+  rules contain recipients of age plugins other than age-plugin-yubikey
+  are always rekeyed.</p>
 </dd>
 </dl>
 

--- a/docs/ragenix.1.ronn
+++ b/docs/ragenix.1.ronn
@@ -62,13 +62,15 @@ store.
     encrypted to the recipients given in the rules configuration file,
     leaving the files untouched.
 
-    `ragenix` decides based on the age header of a secret file: SSH
-    recipients are compared by their fingerprint tags while X25519
-    recipients are only compared by their number as age files do not
-    identify X25519 recipients by design. Consequently, replacing an X25519
-    recipient with another one does not cause a rekey of a secret. The same
-    holds for removing a plugin recipient. After such changes, rekey without
-    the `--lazy` option.
+    `ragenix` decides based on the age header of a secret file: SSH and
+    YubiKey (age-plugin-yubikey) recipients are compared by their
+    fingerprint tags while X25519 recipients are only compared by their
+    number as age files do not identify X25519 recipients by design.
+    Consequently, replacing an X25519 recipient with another one or removing
+    a recipient of any other age plugin does not cause a rekey of a secret.
+    After such changes, rekey without the `--lazy` option. Secrets whose
+    rules contain recipients of age plugins other than age-plugin-yubikey
+    are always rekeyed.
 
 ## COMMON OPTIONS
 

--- a/docs/ragenix.1.ronn
+++ b/docs/ragenix.1.ronn
@@ -3,9 +3,9 @@ ragenix(1) -- age-encrypted secrets for Nix
 
 ## SYNOPSIS
 
-`ragenix` [`--rules` <PATH>=./secrets.nix] [`-i` <PATH>]... (`-e` <PATH> | `-r`)<br>
+`ragenix` [`--rules` <PATH>=./secrets.nix] [`-i` <PATH>]... (`-e` <PATH> | `-r` [`-l`])<br>
 `ragenix` `-e` <PATH><br>
-`ragenix` `-r`<br>
+`ragenix` `-r` [`-l`]<br>
 
 ## DESCRIPTION
 
@@ -56,6 +56,19 @@ store.
 
     When rekeying, `ragenix` does not write any plaintext data to disk; all
     processing happens in-memory.
+
+* `-l`, `--lazy`:
+    Only valid in combination with `--rekey`. Skip secrets which are already
+    encrypted to the recipients given in the rules configuration file,
+    leaving the files untouched.
+
+    `ragenix` decides based on the age header of a secret file: SSH
+    recipients are compared by their fingerprint tags while X25519
+    recipients are only compared by their number as age files do not
+    identify X25519 recipients by design. Consequently, replacing an X25519
+    recipient with another one does not cause a rekey of a secret. The same
+    holds for removing a plugin recipient. After such changes, rekey without
+    the `--lazy` option.
 
 ## COMMON OPTIONS
 

--- a/src/age.rs
+++ b/src/age.rs
@@ -17,6 +17,7 @@ use age::{
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD, BASE64_STANDARD_NO_PAD};
+use bech32::FromBase32;
 use sha2::{Digest, Sha256};
 
 use color_eyre::{
@@ -203,52 +204,66 @@ pub(crate) fn encrypt<P: AsRef<Path>>(
 
 /// The recipients of an age file as far as its header reveals them.
 ///
-/// SSH recipients are identified by the key fingerprint tag age embeds in
-/// their stanzas. X25519 recipients are unlinkable by design, so only their
-/// number is known.
+/// SSH and `YubiKey` recipients are identified by the key fingerprint tag their
+/// stanzas embed, qualified by the stanza type (e.g. `ssh-ed25519 a6H7Ng`).
+/// X25519 recipients are unlinkable by design, so only their number is known.
 #[derive(Debug, PartialEq, Eq)]
 struct RecipientFingerprint {
-    ssh_tags: Vec<String>,
+    tags: Vec<String>,
     x25519_count: usize,
 }
 
-/// Compute the tag age uses in stanzas of SSH recipients: the unpadded
+/// Encode a recipient tag the way age writes it to a stanza: the unpadded
 /// base64 encoding of the first four bytes of the SHA-256 digest of the
-/// SSH public key blob.
+/// recipient's key material.
+fn stanza_tag(key_material: &[u8]) -> String {
+    let digest = Sha256::digest(key_material);
+    BASE64_STANDARD_NO_PAD.encode(&digest[..4])
+}
+
+/// Compute the stanza type and tag of an SSH recipient. The tag is derived
+/// from the SSH public key blob.
 fn ssh_recipient_tag(pubkey: &str) -> Result<String> {
-    let blob_b64 = pubkey
-        .split_whitespace()
-        .nth(1)
-        .ok_or_else(|| eyre!("Invalid SSH public key: {}", pubkey))?;
+    let mut fields = pubkey.split_whitespace();
+    let (Some(key_type), Some(blob_b64)) = (fields.next(), fields.next()) else {
+        return Err(eyre!("Invalid SSH public key: {}", pubkey));
+    };
     let blob = BASE64_STANDARD.decode(blob_b64)?;
-    let digest = Sha256::digest(&blob);
-    Ok(BASE64_STANDARD_NO_PAD.encode(&digest[..4]))
+    Ok(format!("{} {}", key_type, stanza_tag(&blob)))
+}
+
+/// Compute the stanza type and tag of an `age-plugin-yubikey` recipient. The
+/// tag is derived from the bech32-encoded compressed public key.
+fn yubikey_recipient_tag(pubkey: &str) -> Result<String> {
+    let (_hrp, data, _variant) = bech32::decode(pubkey)?;
+    let compressed_point = Vec::<u8>::from_base32(&data)?;
+    Ok(format!("piv-p256 {}", stanza_tag(&compressed_point)))
 }
 
 /// Compute the [`RecipientFingerprint`] an age file would have if it were
 /// encrypted to exactly the given public keys.
 ///
-/// Returns `Ok(None)` if any key is a plugin recipient as those cannot be
-/// identified in an age header.
+/// Returns `Ok(None)` if any key is a plugin recipient other than a `YubiKey`
+/// as those cannot be identified in an age header.
 fn fingerprint_public_keys(public_keys: &[String]) -> Result<Option<RecipientFingerprint>> {
-    let mut ssh_tags: Vec<String> = vec![];
+    let mut tags: Vec<String> = vec![];
     let mut x25519_count: usize = 0;
 
     for pubkey in public_keys {
         if pubkey.parse::<age::x25519::Recipient>().is_ok() {
             x25519_count += 1;
         } else if pubkey.parse::<age::ssh::Recipient>().is_ok() {
-            ssh_tags.push(ssh_recipient_tag(pubkey)?);
+            tags.push(ssh_recipient_tag(pubkey)?);
+        } else if matches!(pubkey.parse::<age::plugin::Recipient>(), Ok(r) if r.plugin() == "yubikey")
+        {
+            tags.push(yubikey_recipient_tag(pubkey)?);
         } else {
             return Ok(None);
         }
     }
 
-    ssh_tags.sort_unstable();
-    Ok(Some(RecipientFingerprint {
-        ssh_tags,
-        x25519_count,
-    }))
+    tags.sort_unstable();
+    Ok(Some(RecipientFingerprint { tags, x25519_count }))
 }
 
 /// Read the [`RecipientFingerprint`] from the header of an age-encrypted file.
@@ -266,7 +281,7 @@ fn fingerprint_encrypted_file<P: AsRef<Path>>(path: P) -> Result<Option<Recipien
         return Ok(None);
     }
 
-    let mut ssh_tags: Vec<String> = vec![];
+    let mut tags: Vec<String> = vec![];
     let mut x25519_count: usize = 0;
 
     loop {
@@ -282,31 +297,31 @@ fn fingerprint_encrypted_file<P: AsRef<Path>>(path: P) -> Result<Option<Recipien
             let mut args = stanza.split_whitespace();
             match (args.next(), args.next()) {
                 (Some("X25519"), Some(_)) => x25519_count += 1,
-                (Some("ssh-ed25519" | "ssh-rsa"), Some(tag)) => ssh_tags.push(tag.to_string()),
+                (Some(stanza_type @ ("ssh-ed25519" | "ssh-rsa" | "piv-p256")), Some(tag)) => {
+                    tags.push(format!("{stanza_type} {tag}"));
+                }
                 (Some("scrypt"), _) => return Ok(None),
-                // Any other stanza is grease or belongs to a plugin recipient;
-                // neither identifies a recipient we could compare to the rules
+                // Any other stanza is grease or belongs to an unsupported
+                // plugin; neither identifies a recipient we could compare to
+                // the rules
                 _ => (),
             }
         }
         // All other lines are stanza body lines which don't identify recipients
     }
 
-    ssh_tags.sort_unstable();
-    Ok(Some(RecipientFingerprint {
-        ssh_tags,
-        x25519_count,
-    }))
+    tags.sort_unstable();
+    Ok(Some(RecipientFingerprint { tags, x25519_count }))
 }
 
 /// Check whether a file is already encrypted to exactly the given public
 /// keys, as far as its age header reveals.
 ///
-/// SSH recipients are compared by their fingerprint tags. As age hides the
-/// identity of X25519 recipients, they are only compared by count; replacing
-/// an X25519 recipient with another one goes unnoticed. Rules with plugin
-/// recipients never match, and plugin stanzas in the file are ignored as
-/// they cannot be told apart from grease.
+/// SSH and `YubiKey` (`age-plugin-yubikey`) recipients are compared by their
+/// fingerprint tags. As age hides the identity of X25519 recipients, they are
+/// only compared by count; replacing an X25519 recipient with another one
+/// goes unnoticed. Rules with other plugin recipients never match, and their
+/// stanzas in the file are ignored as they cannot be told apart from grease.
 pub(crate) fn encrypted_to_recipients<P: AsRef<Path>>(
     path: P,
     public_keys: &[String],
@@ -375,15 +390,38 @@ mod test_encrypted_to_recipients {
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILoPdkEfhcsmW6Lg86GMrEJZnYfFBb7fL9G/IXK7pDQd";
     const SSH_RSA: &str = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDHd3yBYhZbBkMqycy/SOgx9d79TV5Q76czfkmKUKVzywUJbJCwZ4wMA+ff7QzBufZRoAWpGeQb+rssLQEOwR+VX30Fw7K92W4kK6BCF5phP6AUCo07e3vjGqKvgJ4+8LYvcCB17bYf8pJhb4GoOGLrlJNKbGZOhfYE0eGFu/fWsVybQasC2naieKfqHOwS9kNK0N1gSnWh0qu3Du9vBAbQBEE13mPGe4zEdIzTogM068xgKhfJUWqu1xCyVBVJNdz9Xw0NLaWQJon8YXDe62ifxLj3LgndwKm91cN9mmL0klcGB5O8K2mPE0ZGFMDuxdcllUchQgYXdNxEWB4EvpkvpQbiO+fjgMpHeEEiNPd/v06amSBqK+QlIGEkPAElELphPLiTJmHVqxc5NaffVc7F+zM+c3+aWB5Fqgk1jcnqm8HmlLEvPPT1S00c80SkY1V3lUUOirFlciP/pEivJejA5Yj2i1NEEELnrCdBw/xQ4jfesIxcqmBhxk5dWeBbfGs=";
 
+    // Bech32 encoding of the compressed public key of a P-256 keypair
+    const YUBIKEY: &str = "age1yubikey1qvqx4uc6pztta4l9w3f9a60787nw9nf8wc3m03a9c3ercw94xzpr70zgfxn";
+    // Same public key encoded for a made-up, unsupported plugin
+    const FAKE_PLUGIN: &str = "age1tpm1qvqx4uc6pztta4l9w3f9a60787nw9nf8wc3m03a9c3ercw94xzpr77zxyha";
+
+    // Created with `rage -a -r age1yubikey1qvqx4... <<< "test secret"` and a
+    // real `age-plugin-yubikey` binary
+    const YUBIKEY_ENCRYPTED_FILE: &str = "-----BEGIN AGE ENCRYPTED FILE-----
+YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IEswcWxMZyBBZ1ZTSmJk
+RTJYUVpaSWRVUFMyL3lqWWZ2YjFwZWJYN0YwMlYzWFZlOW1SYwp6WXdRY3FxZEJF
+a1JwbXdqdW1uSDNIVUx1eVIzV1dBUWt2ekNNOFJqYXRNCi0+IGs2IlFrLWdyZWFz
+ZQpTVEVaZ281YzRoZkUKLS0tIDNBYWVEaHpsazR2RGMwYnVHUTVhNXJQRmx0L2h5
+cUVxcVFIRnAwMGhYUFEKZLDq5IV2hqf03nsS4/rpO/g6TIS57j8CwYrjf0jRnoZC
+8UXf1YdrK8zPrdQ=
+-----END AGE ENCRYPTED FILE-----
+";
+
     fn example_file() -> &'static str {
         concat!(env!("CARGO_MANIFEST_DIR"), "/example/root.passwd.age")
+    }
+
+    fn yubikey_encrypted_file() -> Result<NamedTempFile> {
+        let file = NamedTempFile::new()?;
+        fs::write(&file, YUBIKEY_ENCRYPTED_FILE)?;
+        Ok(file)
     }
 
     #[test]
     fn computes_tags_age_writes_to_stanzas() -> Result<()> {
         // Expected values taken from the header of `example/root.passwd.age`
-        assert_eq!(ssh_recipient_tag(SSH_ED25519)?, "a6H7Ng");
-        assert_eq!(ssh_recipient_tag(SSH_RSA)?, "1NDNnA");
+        assert_eq!(ssh_recipient_tag(SSH_ED25519)?, "ssh-ed25519 a6H7Ng");
+        assert_eq!(ssh_recipient_tag(SSH_RSA)?, "ssh-rsa 1NDNnA");
         Ok(())
     }
 
@@ -419,15 +457,46 @@ mod test_encrypted_to_recipients {
     }
 
     #[test]
-    fn never_matches_plugin_recipients() -> Result<()> {
-        let public_keys: Vec<String> = [
-            X25519,
-            SSH_ED25519,
-            SSH_RSA,
-            "age1yubikey1qwt50d05nh5vutpdzmlg5wn80xq5negm4uj9y5q0jvzgxrq2yn2vsy5g5gd",
-        ]
-        .map(String::from)
-        .to_vec();
+    fn computes_tag_age_plugin_yubikey_writes_to_stanzas() -> Result<()> {
+        // Expected value taken from the header of [`YUBIKEY_ENCRYPTED_FILE`]
+        assert_eq!(yubikey_recipient_tag(YUBIKEY)?, "piv-p256 K0qlLg");
+        Ok(())
+    }
+
+    #[test]
+    fn matches_unchanged_yubikey_recipients() -> Result<()> {
+        let file = yubikey_encrypted_file()?;
+        let public_keys: Vec<String> = [YUBIKEY].map(String::from).to_vec();
+        assert!(encrypted_to_recipients(file.path(), &public_keys)?);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_changed_yubikey_recipients() -> Result<()> {
+        let file = yubikey_encrypted_file()?;
+
+        // Additional X25519 recipient
+        let public_keys: Vec<String> = [YUBIKEY, X25519].map(String::from).to_vec();
+        assert!(!encrypted_to_recipients(file.path(), &public_keys)?);
+
+        // YubiKey recipient replaced by an SSH recipient
+        let public_keys: Vec<String> = [SSH_ED25519].map(String::from).to_vec();
+        assert!(!encrypted_to_recipients(file.path(), &public_keys)?);
+
+        // File not encrypted to the YubiKey recipient
+        let public_keys: Vec<String> = [X25519, SSH_ED25519, SSH_RSA, YUBIKEY]
+            .map(String::from)
+            .to_vec();
+        assert!(!encrypted_to_recipients(example_file(), &public_keys)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn never_matches_other_plugin_recipients() -> Result<()> {
+        let public_keys: Vec<String> = [X25519, SSH_ED25519, SSH_RSA, FAKE_PLUGIN]
+            .map(String::from)
+            .to_vec();
         assert!(!encrypted_to_recipients(example_file(), &public_keys)?);
         Ok(())
     }

--- a/src/age.rs
+++ b/src/age.rs
@@ -3,7 +3,7 @@
 use std::{
     convert::Into,
     fs,
-    io::{self, BufReader},
+    io::{self, BufRead, BufReader},
     path::Path,
 };
 
@@ -15,6 +15,9 @@ use age::{
     },
     decryptor::RecipientsDecryptor,
 };
+
+use base64::prelude::{Engine, BASE64_STANDARD, BASE64_STANDARD_NO_PAD};
+use sha2::{Digest, Sha256};
 
 use color_eyre::{
     eyre::{eyre, Result, WrapErr},
@@ -198,6 +201,122 @@ pub(crate) fn encrypt<P: AsRef<Path>>(
     Ok(())
 }
 
+/// The recipients of an age file as far as its header reveals them.
+///
+/// SSH recipients are identified by the key fingerprint tag age embeds in
+/// their stanzas. X25519 recipients are unlinkable by design, so only their
+/// number is known.
+#[derive(Debug, PartialEq, Eq)]
+struct RecipientFingerprint {
+    ssh_tags: Vec<String>,
+    x25519_count: usize,
+}
+
+/// Compute the tag age uses in stanzas of SSH recipients: the unpadded
+/// base64 encoding of the first four bytes of the SHA-256 digest of the
+/// SSH public key blob.
+fn ssh_recipient_tag(pubkey: &str) -> Result<String> {
+    let blob_b64 = pubkey
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| eyre!("Invalid SSH public key: {}", pubkey))?;
+    let blob = BASE64_STANDARD.decode(blob_b64)?;
+    let digest = Sha256::digest(&blob);
+    Ok(BASE64_STANDARD_NO_PAD.encode(&digest[..4]))
+}
+
+/// Compute the [`RecipientFingerprint`] an age file would have if it were
+/// encrypted to exactly the given public keys.
+///
+/// Returns `Ok(None)` if any key is a plugin recipient as those cannot be
+/// identified in an age header.
+fn fingerprint_public_keys(public_keys: &[String]) -> Result<Option<RecipientFingerprint>> {
+    let mut ssh_tags: Vec<String> = vec![];
+    let mut x25519_count: usize = 0;
+
+    for pubkey in public_keys {
+        if pubkey.parse::<age::x25519::Recipient>().is_ok() {
+            x25519_count += 1;
+        } else if pubkey.parse::<age::ssh::Recipient>().is_ok() {
+            ssh_tags.push(ssh_recipient_tag(pubkey)?);
+        } else {
+            return Ok(None);
+        }
+    }
+
+    ssh_tags.sort_unstable();
+    Ok(Some(RecipientFingerprint {
+        ssh_tags,
+        x25519_count,
+    }))
+}
+
+/// Read the [`RecipientFingerprint`] from the header of an age-encrypted file.
+///
+/// Returns `Ok(None)` if the file is not a valid age file or contains a
+/// stanza which cannot be attributed to an SSH or X25519 recipient.
+fn fingerprint_encrypted_file<P: AsRef<Path>>(path: P) -> Result<Option<RecipientFingerprint>> {
+    let s = path.as_ref().to_str().map(std::string::ToString::to_string);
+    let input_reader = InputReader::new(s)?;
+    let mut reader = BufReader::new(ArmoredReader::new(input_reader));
+
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    if line.trim_end() != "age-encryption.org/v1" {
+        return Ok(None);
+    }
+
+    let mut ssh_tags: Vec<String> = vec![];
+    let mut x25519_count: usize = 0;
+
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            // Header ended without a MAC line; not a valid age file
+            return Ok(None);
+        }
+        if line.starts_with("---") {
+            break;
+        }
+        if let Some(stanza) = line.strip_prefix("-> ") {
+            let mut args = stanza.split_whitespace();
+            match (args.next(), args.next()) {
+                (Some("X25519"), Some(_)) => x25519_count += 1,
+                (Some("ssh-ed25519" | "ssh-rsa"), Some(tag)) => ssh_tags.push(tag.to_string()),
+                (Some("scrypt"), _) => return Ok(None),
+                // Any other stanza is grease or belongs to a plugin recipient;
+                // neither identifies a recipient we could compare to the rules
+                _ => (),
+            }
+        }
+        // All other lines are stanza body lines which don't identify recipients
+    }
+
+    ssh_tags.sort_unstable();
+    Ok(Some(RecipientFingerprint {
+        ssh_tags,
+        x25519_count,
+    }))
+}
+
+/// Check whether a file is already encrypted to exactly the given public
+/// keys, as far as its age header reveals.
+///
+/// SSH recipients are compared by their fingerprint tags. As age hides the
+/// identity of X25519 recipients, they are only compared by count; replacing
+/// an X25519 recipient with another one goes unnoticed. Rules with plugin
+/// recipients never match, and plugin stanzas in the file are ignored as
+/// they cannot be told apart from grease.
+pub(crate) fn encrypted_to_recipients<P: AsRef<Path>>(
+    path: P,
+    public_keys: &[String],
+) -> Result<bool> {
+    match fingerprint_public_keys(public_keys)? {
+        Some(expected) => Ok(fingerprint_encrypted_file(path)? == Some(expected)),
+        None => Ok(false),
+    }
+}
+
 /// Re-encrypt a file in memory using the given public keys.
 ///
 /// Decrypts the file and stream-encrypts the contents into a temporary
@@ -245,4 +364,79 @@ pub(crate) fn rekey<P: AsRef<Path>>(
 
             Ok(())
         })
+}
+
+#[cfg(test)]
+mod test_encrypted_to_recipients {
+    use super::*;
+
+    const X25519: &str = "age1wl3fqfvyml0c5eaj00j0frad4vhspgx9t8sngq4342j7rzjw4pqs80euxk";
+    const SSH_ED25519: &str =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILoPdkEfhcsmW6Lg86GMrEJZnYfFBb7fL9G/IXK7pDQd";
+    const SSH_RSA: &str = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDHd3yBYhZbBkMqycy/SOgx9d79TV5Q76czfkmKUKVzywUJbJCwZ4wMA+ff7QzBufZRoAWpGeQb+rssLQEOwR+VX30Fw7K92W4kK6BCF5phP6AUCo07e3vjGqKvgJ4+8LYvcCB17bYf8pJhb4GoOGLrlJNKbGZOhfYE0eGFu/fWsVybQasC2naieKfqHOwS9kNK0N1gSnWh0qu3Du9vBAbQBEE13mPGe4zEdIzTogM068xgKhfJUWqu1xCyVBVJNdz9Xw0NLaWQJon8YXDe62ifxLj3LgndwKm91cN9mmL0klcGB5O8K2mPE0ZGFMDuxdcllUchQgYXdNxEWB4EvpkvpQbiO+fjgMpHeEEiNPd/v06amSBqK+QlIGEkPAElELphPLiTJmHVqxc5NaffVc7F+zM+c3+aWB5Fqgk1jcnqm8HmlLEvPPT1S00c80SkY1V3lUUOirFlciP/pEivJejA5Yj2i1NEEELnrCdBw/xQ4jfesIxcqmBhxk5dWeBbfGs=";
+
+    fn example_file() -> &'static str {
+        concat!(env!("CARGO_MANIFEST_DIR"), "/example/root.passwd.age")
+    }
+
+    #[test]
+    fn computes_tags_age_writes_to_stanzas() -> Result<()> {
+        // Expected values taken from the header of `example/root.passwd.age`
+        assert_eq!(ssh_recipient_tag(SSH_ED25519)?, "a6H7Ng");
+        assert_eq!(ssh_recipient_tag(SSH_RSA)?, "1NDNnA");
+        Ok(())
+    }
+
+    #[test]
+    fn matches_unchanged_recipients() -> Result<()> {
+        let public_keys: Vec<String> = [X25519, SSH_ED25519, SSH_RSA].map(String::from).to_vec();
+        assert!(encrypted_to_recipients(example_file(), &public_keys)?);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_changed_recipients() -> Result<()> {
+        // Removed SSH recipient
+        let public_keys: Vec<String> = [X25519, SSH_ED25519].map(String::from).to_vec();
+        assert!(!encrypted_to_recipients(example_file(), &public_keys)?);
+
+        // Removed X25519 recipient
+        let public_keys: Vec<String> = [SSH_ED25519, SSH_RSA].map(String::from).to_vec();
+        assert!(!encrypted_to_recipients(example_file(), &public_keys)?);
+
+        // Additional X25519 recipient
+        let public_keys: Vec<String> = [
+            X25519,
+            SSH_ED25519,
+            SSH_RSA,
+            "age1fjc9tyguvxfqh2ey2qqfc066g3gee7hlnhqn2g7yn4f6smymmsnq6xdn2t",
+        ]
+        .map(String::from)
+        .to_vec();
+        assert!(!encrypted_to_recipients(example_file(), &public_keys)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn never_matches_plugin_recipients() -> Result<()> {
+        let public_keys: Vec<String> = [
+            X25519,
+            SSH_ED25519,
+            SSH_RSA,
+            "age1yubikey1qwt50d05nh5vutpdzmlg5wn80xq5negm4uj9y5q0jvzgxrq2yn2vsy5g5gd",
+        ]
+        .map(String::from)
+        .to_vec();
+        assert!(!encrypted_to_recipients(example_file(), &public_keys)?);
+        Ok(())
+    }
+
+    #[test]
+    fn never_matches_non_age_files() -> Result<()> {
+        let rules_file = concat!(env!("CARGO_MANIFEST_DIR"), "/example/secrets.nix");
+        let public_keys: Vec<String> = [X25519].map(String::from).to_vec();
+        assert!(!encrypted_to_recipients(rules_file, &public_keys)?);
+        Ok(())
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,11 +7,13 @@ use clap::{
 };
 
 #[allow(dead_code)] // False positive
+#[allow(clippy::struct_excessive_bools)] // Mirrors the independent CLI flags
 #[derive(Debug, Clone)]
 pub(crate) struct Opts {
     pub edit: Option<String>,
     pub editor: Option<String>,
     pub identities: Option<Vec<String>>,
+    pub lazy: bool,
     pub rekey: bool,
     pub rules: String,
     pub schema: bool,
@@ -38,6 +40,14 @@ fn build() -> Command {
                 .help("re-encrypts all secrets with specified recipients")
                 .long("rekey")
                 .short('r')
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("lazy")
+                .help("when rekeying, skip secrets which are already encrypted to the recipients")
+                .long("lazy")
+                .short('l')
+                .requires("rekey")
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -107,6 +117,7 @@ where
         identities: matches
             .get_many::<String>("identity")
             .map(|vals| vals.cloned().collect::<Vec<_>>()),
+        lazy: matches.get_flag("lazy"),
         rekey: matches.get_flag("rekey"),
         rules: matches
             .get_one::<String>("rules")

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
             let editor = &opts.editor.unwrap();
             ragenix::edit(&rule, &identities, editor, &mut std::io::stdout())?;
         } else if opts.rekey {
-            ragenix::rekey(&rules, &identities, &mut std::io::stdout())?;
+            ragenix::rekey(&rules, &identities, opts.lazy, &mut std::io::stdout())?;
         }
     }
 

--- a/src/ragenix/mod.rs
+++ b/src/ragenix/mod.rs
@@ -143,14 +143,26 @@ pub(crate) fn parse_rules<P: AsRef<Path>>(rules_path: P) -> Result<Vec<RagenixRu
 }
 
 /// Rekey all entries with the specified public keys
+///
+/// If `lazy` is set, entries which are already encrypted to their configured
+/// recipients are skipped.
 pub(crate) fn rekey(
     entries: &[RagenixRule],
     identities: &[String],
+    lazy: bool,
     mut writer: impl Write,
 ) -> Result<()> {
     let identities = age::get_identities(identities)?;
     for entry in entries {
         if entry.path.exists() {
+            if lazy && age::encrypted_to_recipients(&entry.path, &entry.public_keys)? {
+                writeln!(
+                    writer,
+                    "Recipients unchanged, skipping: {}",
+                    entry.path.display()
+                )?;
+                continue;
+            }
             writeln!(writer, "Rekeying {}", entry.path.display())?;
             age::rekey(&entry.path, &identities, &entry.public_keys)?;
         } else {

--- a/tests/ragenix.rs
+++ b/tests/ragenix.rs
@@ -269,6 +269,130 @@ fn rekeying_works() -> Result<()> {
 
 #[test]
 #[cfg_attr(not(feature = "recursive-nix"), ignore)]
+fn rekeying_lazy_skips_unchanged() -> Result<()> {
+    let (_dir, path) = copy_example_to_tmpdir()?;
+
+    let files = &["github-runner.token.age", "root.passwd.age"];
+
+    // Ensure the files are encrypted to the recipients of the current rules
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    cmd.current_dir(&path)
+        .arg("--rekey")
+        .arg("--identity")
+        .arg("keys/id_ed25519")
+        .assert()
+        .success();
+
+    let contents_before = files
+        .iter()
+        .map(|f| fs::read(path.join(f)))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let expected = files
+        .iter()
+        .map(|s| path.join(s))
+        .map(|p| format!("Recipients unchanged, skipping: {}", p.display()))
+        .collect::<Vec<String>>()
+        .join("\n")
+        + "\n";
+
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    let assert = cmd
+        .current_dir(&path)
+        .arg("--rekey")
+        .arg("--lazy")
+        .arg("--identity")
+        .arg("keys/id_ed25519")
+        .assert();
+
+    assert.success().stdout(expected);
+
+    // Skipped files remain untouched
+    for (file, before) in files.iter().zip(contents_before) {
+        assert_eq!(fs::read(path.join(file))?, before);
+    }
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
+fn rekeying_lazy_rekeys_changed_recipients() -> Result<()> {
+    let (_dir, path) = copy_example_to_tmpdir()?;
+
+    // Ensure the files are encrypted to the recipients of the current rules
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    cmd.current_dir(&path)
+        .arg("--rekey")
+        .arg("--identity")
+        .arg("keys/id_ed25519")
+        .assert()
+        .success();
+
+    // Drop the ssh-rsa recipient of root.passwd.age from the rules
+    let rules = indoc! {r#"
+    let
+      age = "age1wl3fqfvyml0c5eaj00j0frad4vhspgx9t8sngq4342j7rzjw4pqs80euxk";
+      sshEd25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILoPdkEfhcsmW6Lg86GMrEJZnYfFBb7fL9G/IXK7pDQd";
+      sshRsa = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDHd3yBYhZbBkMqycy/SOgx9d79TV5Q76czfkmKUKVzywUJbJCwZ4wMA+ff7QzBufZRoAWpGeQb+rssLQEOwR+VX30Fw7K92W4kK6BCF5phP6AUCo07e3vjGqKvgJ4+8LYvcCB17bYf8pJhb4GoOGLrlJNKbGZOhfYE0eGFu/fWsVybQasC2naieKfqHOwS9kNK0N1gSnWh0qu3Du9vBAbQBEE13mPGe4zEdIzTogM068xgKhfJUWqu1xCyVBVJNdz9Xw0NLaWQJon8YXDe62ifxLj3LgndwKm91cN9mmL0klcGB5O8K2mPE0ZGFMDuxdcllUchQgYXdNxEWB4EvpkvpQbiO+fjgMpHeEEiNPd/v06amSBqK+QlIGEkPAElELphPLiTJmHVqxc5NaffVc7F+zM+c3+aWB5Fqgk1jcnqm8HmlLEvPPT1S00c80SkY1V3lUUOirFlciP/pEivJejA5Yj2i1NEEELnrCdBw/xQ4jfesIxcqmBhxk5dWeBbfGs=";
+    in
+    {
+      "root.passwd.age".publicKeys = [ age sshEd25519 ];
+      "github-runner.token.age".publicKeys = [ age sshEd25519 sshRsa ];
+    }
+    "#};
+    fs::write(path.join("secrets.nix"), rules)?;
+
+    let expected = format!(
+        "Recipients unchanged, skipping: {}\nRekeying {}\n",
+        path.join("github-runner.token.age").display(),
+        path.join("root.passwd.age").display()
+    );
+
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    let assert = cmd
+        .current_dir(&path)
+        .arg("--rekey")
+        .arg("--lazy")
+        .arg("--identity")
+        .arg("keys/id_ed25519")
+        .assert();
+
+    assert.success().stdout(expected);
+
+    // A second lazy rekey skips both files
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    let assert = cmd
+        .current_dir(&path)
+        .arg("--rekey")
+        .arg("--lazy")
+        .arg("--identity")
+        .arg("keys/id_ed25519")
+        .assert();
+
+    assert
+        .success()
+        .stdout(predicate::str::contains("Rekeying").not());
+
+    Ok(())
+}
+
+#[test]
+fn lazy_requires_rekey() -> Result<()> {
+    let mut cmd = Command::cargo_bin(crate_name!())?;
+    let assert = cmd
+        .arg("--edit")
+        .arg("some-file.age")
+        .arg("--lazy")
+        .assert();
+
+    assert.failure().stderr(predicate::str::contains("--rekey"));
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(not(feature = "recursive-nix"), ignore)]
 fn rekeying_ignores_not_existing_files() -> Result<()> {
     let (_dir, path) = copy_example_to_tmpdir()?;
 


### PR DESCRIPTION
When invoked as `ragenix --rekey --lazy`, secrets which are already encrypted to the recipients of the rules file are skipped, leaving the files untouched instead of rewriting them on every rekey.

The check inspects the age header only: SSH recipients are compared by the fingerprint tag age embeds in their stanzas while X25519 recipients are merely compared by count as age hides their identity by design.

Rules with plugin recipients always rekey, and unknown stanzas are ignored since they cannot be told apart from grease.